### PR TITLE
비밀번호 유효성 검증 Validator 및 Validation 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,9 @@ dependencies {
 
     //spotify
     implementation 'se.michaelthelin.spotify:spotify-web-api-java:8.4.1'
+
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/my/firstbeat/web/config/security/loginuser/dto/LoginRequest.java
+++ b/src/main/java/com/my/firstbeat/web/config/security/loginuser/dto/LoginRequest.java
@@ -12,11 +12,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class LoginRequest {
 
-    @Email(message = "유효한 이메일 형식이 아닙니다")
-    @NotBlank(message = "이메일을 입력해야 합니다")
     private String email;
 
-    @NotBlank(message = "비밀번호를 입력해야 합니다")
-    @ValidPassword
     private String password;
 }

--- a/src/main/java/com/my/firstbeat/web/config/security/loginuser/dto/LoginRequest.java
+++ b/src/main/java/com/my/firstbeat/web/config/security/loginuser/dto/LoginRequest.java
@@ -1,5 +1,8 @@
 package com.my.firstbeat.web.config.security.loginuser.dto;
 
+import com.my.firstbeat.web.controller.user.dto.valid.ValidPassword;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,7 +12,11 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class LoginRequest {
 
-
+    @Email(message = "유효한 이메일 형식이 아닙니다")
+    @NotBlank(message = "이메일을 입력해야 합니다")
     private String email;
+
+    @NotBlank(message = "비밀번호를 입력해야 합니다")
+    @ValidPassword
     private String password;
 }

--- a/src/main/java/com/my/firstbeat/web/config/security/loginuser/dto/LoginRequest.java
+++ b/src/main/java/com/my/firstbeat/web/config/security/loginuser/dto/LoginRequest.java
@@ -8,6 +8,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 public class LoginRequest {
+
+
     private String email;
     private String password;
 }

--- a/src/main/java/com/my/firstbeat/web/controller/user/dto/valid/PasswordValidator.java
+++ b/src/main/java/com/my/firstbeat/web/controller/user/dto/valid/PasswordValidator.java
@@ -1,0 +1,21 @@
+package com.my.firstbeat.web.controller.user.dto.valid;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class PasswordValidator implements ConstraintValidator<ValidPassword, String> {
+
+
+    @Override
+    public boolean isValid(String password, ConstraintValidatorContext constraintValidatorContext) {
+        if(password == null){
+            return true;
+        }
+
+        if(password.length() < 8 || password.length() > 12){
+            return false;
+        }
+
+        return password.chars().allMatch(Character::isLetterOrDigit);
+    }
+}

--- a/src/main/java/com/my/firstbeat/web/controller/user/dto/valid/ValidPassword.java
+++ b/src/main/java/com/my/firstbeat/web/controller/user/dto/valid/ValidPassword.java
@@ -1,0 +1,21 @@
+package com.my.firstbeat.web.controller.user.dto.valid;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = ElementType.FIELD)
+@Constraint(validatedBy = PasswordValidator.class)
+public @interface ValidPassword {
+
+    String message() default "영문자 숫자 조합 8~12자 사이로 입력해야 합니다";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}


### PR DESCRIPTION
### 비밀번호 유효성 검증 Validator
- 영문자 숫자 조합 8-12자 검사

### Validation 의존성 추가
- dto 유효성 검사를 위한 의존성이 포함되어 있지 않아 이를 추가

### 로그인 시 유효성 검사 제거
- 회원가입에서 유효성 검사를 거친 valid한 값이 저장되어있음에 따라 유효성 검사 어노테이션 제거
- 기존 '로그인 실패' 메시지로 자세한 내용을 노출시키지 않는 방향으로 설정