### PR TITLE
Spotify 제공 장르 목록 저장 기능

### DIFF
--- a/src/main/java/com/my/firstbeat/client/spotify/SpotifyClient.java
+++ b/src/main/java/com/my/firstbeat/client/spotify/SpotifyClient.java
@@ -30,6 +30,17 @@ public class SpotifyClient {
         });
     }
 
+    //제공하는 장르 목록 검색
+    public String[] getGenres(){
+        return executeWithValidToken(() -> {
+            String[] genres = spotifyApi.getAvailableGenreSeeds()
+                    .build()
+                    .execute();
+            log.debug("Spotify API 호출 완료 - getGenreList, size: {}", genres.length);
+            return genres;
+        });
+    }
+
 
     private <T> T executeWithValidToken(SpotifyApiCall<T> apiCall){
         try {

--- a/src/main/java/com/my/firstbeat/client/spotify/SpotifyClient.java
+++ b/src/main/java/com/my/firstbeat/client/spotify/SpotifyClient.java
@@ -4,10 +4,14 @@ import com.my.firstbeat.client.spotify.dto.response.TrackSearchResponse;
 import com.my.firstbeat.client.spotify.ex.SpotifyApiException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.hc.core5.http.ParseException;
 import org.springframework.stereotype.Service;
 import se.michaelthelin.spotify.SpotifyApi;
+import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.model_objects.specification.Paging;
 import se.michaelthelin.spotify.model_objects.specification.Track;
+
+import java.io.IOException;
 
 @Service
 @RequiredArgsConstructor
@@ -46,7 +50,7 @@ public class SpotifyClient {
         try {
             spotifyApi.setAccessToken(spotifyTokenManager.getValidToken());
             return apiCall.execute();
-        } catch (Exception e){
+        } catch (IOException | ParseException | SpotifyWebApiException e){
             log.error("Spotify API 호출 실패: {}", e.getMessage(), e);
             throw new SpotifyApiException(e);
         }

--- a/src/main/java/com/my/firstbeat/web/controller/genre/GenreController.java
+++ b/src/main/java/com/my/firstbeat/web/controller/genre/GenreController.java
@@ -1,12 +1,16 @@
 package com.my.firstbeat.web.controller.genre;
 
 import com.my.firstbeat.client.spotify.dto.response.TrackSearchResponse;
+import com.my.firstbeat.web.service.GenreService;
 import com.my.firstbeat.web.service.TrackService;
 import com.my.firstbeat.web.util.api.ApiResult;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -16,11 +20,19 @@ import org.springframework.web.bind.annotation.RestController;
 public class GenreController {
 
     private final TrackService trackService;
+    private final GenreService genreService;
 
-    @GetMapping("/auth/search/track") //임시 api
+    @GetMapping("/auth/search/tracks") //임시 api
     public ResponseEntity<ApiResult<TrackSearchResponse>> searchTrackList(@RequestParam(value = "genre", required = true) String genre,
-                                                                          @RequestParam(value = "page", required = false, defaultValue = "0") Long page,
-                                                                          @RequestParam(value = "limit", required = false, defaultValue = "20")  Long limit){
+                                                                          @RequestParam(value = "page", required = false, defaultValue = "0") @PositiveOrZero Long page,
+                                                                          @RequestParam(value = "limit", required = false, defaultValue = "20") @Positive Long limit){
         return ResponseEntity.ok(ApiResult.success(trackService.searchTrackList(genre)));
     }
+
+    @PostMapping("/api/v1/genres")
+    public ResponseEntity<ApiResult<String>> getAndUpdateGenreList(){
+        genreService.updateGenreList();
+        return ResponseEntity.ok(ApiResult.success("Spotify에서 제공하는 장르 목록 저장 완료"));
+    }
+
 }

--- a/src/main/java/com/my/firstbeat/web/controller/genre/GenreController.java
+++ b/src/main/java/com/my/firstbeat/web/controller/genre/GenreController.java
@@ -22,7 +22,7 @@ public class GenreController {
     private final TrackService trackService;
     private final GenreService genreService;
 
-    @GetMapping("/auth/search/tracks") //임시 api
+    @GetMapping("/api/v1/search/tracks")
     public ResponseEntity<ApiResult<TrackSearchResponse>> searchTrackList(@RequestParam(value = "genre", required = true) String genre,
                                                                           @RequestParam(value = "page", required = false, defaultValue = "0") @PositiveOrZero Long page,
                                                                           @RequestParam(value = "limit", required = false, defaultValue = "20") @Positive Long limit){

--- a/src/main/java/com/my/firstbeat/web/controller/genre/GenreController.java
+++ b/src/main/java/com/my/firstbeat/web/controller/genre/GenreController.java
@@ -5,18 +5,22 @@ import com.my.firstbeat.web.service.TrackService;
 import com.my.firstbeat.web.util.api.ApiResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@Validated
 public class GenreController {
 
     private final TrackService trackService;
 
     @GetMapping("/auth/search/track") //임시 api
-    public ResponseEntity<ApiResult<TrackSearchResponse>> searchTrackList(@RequestParam(value = "genre") String genre){
+    public ResponseEntity<ApiResult<TrackSearchResponse>> searchTrackList(@RequestParam(value = "genre", required = true) String genre,
+                                                                          @RequestParam(value = "page", required = false, defaultValue = "0") Long page,
+                                                                          @RequestParam(value = "limit", required = false, defaultValue = "20")  Long limit){
         return ResponseEntity.ok(ApiResult.success(trackService.searchTrackList(genre)));
     }
 }

--- a/src/main/java/com/my/firstbeat/web/domain/genre/Genre.java
+++ b/src/main/java/com/my/firstbeat/web/domain/genre/Genre.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -18,4 +19,8 @@ public class Genre extends BaseEntity {
     private Long id;
 
     private String name; // TODO: 우선 spotify에서 제공하는 전체 장르들을 저장하는 것도 괜찮을듯 합니다
+
+    public Genre(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/com/my/firstbeat/web/service/GenreService.java
+++ b/src/main/java/com/my/firstbeat/web/service/GenreService.java
@@ -1,13 +1,50 @@
 package com.my.firstbeat.web.service;
 
+import com.my.firstbeat.client.spotify.SpotifyClient;
+import com.my.firstbeat.web.domain.genre.Genre;
+import com.my.firstbeat.web.domain.genre.GenreRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Slf4j
 public class GenreService {
+
+    private final SpotifyClient spotifyClient;
+    private final GenreRepository genreRepository;
+
+    //장르 데이터 세팅
+    @Transactional
+    public void updateGenreList(){
+        //Spotify 제공 장르 목록 조회
+        HashSet<String> spotifyGenres = new HashSet<>(Arrays.asList(spotifyClient.getGenres()));
+
+        //기존 DB에 있는 장르 목록 조회
+        Set<String> existingGenres = genreRepository.findAll().stream()
+                .map(Genre::getName)
+                .collect(Collectors.toSet());
+
+        //새로 추가된 장르만 필터링
+        Set<String> newGenres = spotifyGenres.stream()
+                .filter(genre -> !existingGenres.contains(genre))
+                .collect(Collectors.toSet());
+
+        if(!newGenres.isEmpty()){
+            List<Genre> genreList = newGenres.stream()
+                    .map(Genre::new)
+                    .toList();
+            genreRepository.saveAll(genreList);
+            log.info("Spotify 새로운 장르 추가: {}개", newGenres.size());
+        } else {
+            log.info("새로 추가된 Spotify 장르가 없습니다");
+        }
+    }
+
 }

--- a/src/test/java/com/my/firstbeat/web/service/GenreServiceTest.java
+++ b/src/test/java/com/my/firstbeat/web/service/GenreServiceTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class GenreServiceTest {
+  
+}

--- a/src/test/java/com/my/firstbeat/web/service/GenreServiceTest.java
+++ b/src/test/java/com/my/firstbeat/web/service/GenreServiceTest.java
@@ -1,4 +1,115 @@
+package com.my.firstbeat.web.service;
+
+import com.my.firstbeat.client.spotify.SpotifyClient;
+import com.my.firstbeat.client.spotify.ex.ErrorCode;
+import com.my.firstbeat.client.spotify.ex.SpotifyApiException;
+import com.my.firstbeat.web.domain.genre.Genre;
+import com.my.firstbeat.web.domain.genre.GenreRepository;
+import org.apache.hc.core5.http.ParseException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
 class GenreServiceTest {
-  
+
+    @InjectMocks
+    private GenreService genreService;
+
+    @Mock
+    private SpotifyClient spotifyClient;
+
+    @Mock
+    private GenreRepository genreRepository;
+
+
+    @Test
+    @DisplayName("새로운 장르 추가 테스트: 정상 케이스")
+    void updateGenreList_success_WithNewGenres(){
+
+        String[] spotifyGenres = {"rock", "jazz", "kpop"};
+        List<Genre> existingGenreList = List.of(new Genre("kpop"));
+
+        when(spotifyClient.getGenres()).thenReturn(spotifyGenres);
+        when(genreRepository.findAll()).thenReturn(existingGenreList);
+
+        genreService.updateGenreList();
+
+        //rock과 jazz만 저장되어야 함
+        ArgumentCaptor<Collection<Genre>> genreCapture = ArgumentCaptor.forClass(Collection.class);
+        verify(genreRepository).saveAll(genreCapture.capture());
+
+        Collection<Genre> savedGenres = genreCapture.getValue();
+        assertAll(
+                () -> assertEquals(2, savedGenres.size()),
+                () -> assertTrue(savedGenres.stream()
+                        .map(Genre::getName)
+                        .collect(Collectors.toSet())
+                        .containsAll(Set.of("rock", "jazz")))
+        );
+    }
+
+    @Test
+    @DisplayName("모든 장르가 이미 존재하는 경우 테스트")
+    void updateGenreList_success_WithAllExistingGenres(){
+
+        String[] spotifyGenres = {"rock", "jazz", "kpop"};
+        List<Genre> existingGenreList = Arrays.stream(spotifyGenres)
+                        .map(Genre::new)
+                                .toList();
+
+        when(spotifyClient.getGenres()).thenReturn(spotifyGenres);
+        when(genreRepository.findAll()).thenReturn(existingGenreList);
+
+        genreService.updateGenreList();
+
+        verify(genreRepository, never()).saveAll(any());
+    }
+
+
+    @Test
+    @DisplayName("Spotify API 호출 중 네트워크 예외 발생 테스트")
+    void updateGenreList_fail_WithSpotifyApiException_IOException(){
+
+        when(spotifyClient.getGenres()).thenThrow(new SpotifyApiException(new IOException()));
+
+        SpotifyApiException exception = assertThrows(SpotifyApiException.class,
+                () -> genreService.updateGenreList());
+
+        assertAll(
+                () -> assertEquals(ErrorCode.NETWORK_ERROR, exception.getErrorCode()),
+                () -> verify(genreRepository, never()).saveAll(any())
+        );
+    }
+
+    @Test
+    @DisplayName("Spotify API 호출 중 파싱 예외 발생 테스트")
+    void updateGenreList_fail_WithSpotifyApiException_ParseException(){
+
+        when(spotifyClient.getGenres()).thenThrow(new SpotifyApiException(new ParseException()));
+
+        SpotifyApiException exception = assertThrows(SpotifyApiException.class,
+                () -> genreService.updateGenreList());
+
+        assertAll(
+                () -> assertEquals(ErrorCode.PARSE_ERROR, exception.getErrorCode()),
+                () -> verify(genreRepository, never()).saveAll(any())
+        );
+    }
 }


### PR DESCRIPTION
### 시나리오
- api: /api/v1/genres
1. 최초 장르 데이터 저장 시 요청
2. 이후 주기적으로 Spotify에서 제공하는 장르 목록을 조회
3. DB에 없는 새 장르가 추가되면 해당 장르 저장

### 단위 테스트 
- GenreServiceTest에서 진행
1. 새로운 장르 추가 테스트: 정상 케이스
2. 모든 장르가 이미 DB에 존재하는 경우 테스트
3. Spotify API 호출 중 네트워크 예외 발생 테스트
4. Spotify API 호출 중 파싱 예외 발생 테스트