### PR TITLE
마이페이지 조회 기능 구현

### DIFF
--- a/src/main/java/com/my/firstbeat/web/controller/user/UserController.java
+++ b/src/main/java/com/my/firstbeat/web/controller/user/UserController.java
@@ -1,9 +1,29 @@
 package com.my.firstbeat.web.controller.user;
 
+import com.my.firstbeat.web.config.security.loginuser.LoginUser;
+import com.my.firstbeat.web.controller.user.dto.response.MyPageResponse;
+import com.my.firstbeat.web.service.UserService;
+import com.my.firstbeat.web.util.api.ApiResult;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
 public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/mypage")
+    public ResponseEntity<ApiResult<MyPageResponse>> getMyPage(@AuthenticationPrincipal LoginUser loginUser) {
+        Long userId = loginUser.getUser().getId();
+
+        MyPageResponse response = userService.getUserData(userId);
+
+        return ResponseEntity.ok(ApiResult.success(response));
+    }
 }

--- a/src/main/java/com/my/firstbeat/web/controller/user/dto/response/MyPageResponse.java
+++ b/src/main/java/com/my/firstbeat/web/controller/user/dto/response/MyPageResponse.java
@@ -1,0 +1,12 @@
+package com.my.firstbeat.web.controller.user.dto.response;
+
+import lombok.AllArgsConstructor;
+
+import java.util.List;
+
+@AllArgsConstructor
+public class MyPageResponse {
+    private String email;
+    private String name;
+    private List<String> genres;
+}

--- a/src/main/java/com/my/firstbeat/web/controller/user/dto/response/MyPageResponse.java
+++ b/src/main/java/com/my/firstbeat/web/controller/user/dto/response/MyPageResponse.java
@@ -1,12 +1,14 @@
 package com.my.firstbeat.web.controller.user.dto.response;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 import java.util.List;
 
+@Getter
 @AllArgsConstructor
 public class MyPageResponse {
-    private String email;
     private String name;
+    private String email;
     private List<String> genres;
 }

--- a/src/main/java/com/my/firstbeat/web/domain/genre/Genre.java
+++ b/src/main/java/com/my/firstbeat/web/domain/genre/Genre.java
@@ -5,14 +5,13 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@AllArgsConstructor
+@Builder
 public class Genre extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/my/firstbeat/web/domain/userGenre/UserGenre.java
+++ b/src/main/java/com/my/firstbeat/web/domain/userGenre/UserGenre.java
@@ -4,14 +4,14 @@ import com.my.firstbeat.web.domain.base.BaseEntity;
 import com.my.firstbeat.web.domain.genre.Genre;
 import com.my.firstbeat.web.domain.user.User;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.yaml.snakeyaml.tokens.ScalarToken;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class UserGenre extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/my/firstbeat/web/domain/userGenre/UserGenreRepository.java
+++ b/src/main/java/com/my/firstbeat/web/domain/userGenre/UserGenreRepository.java
@@ -1,6 +1,8 @@
 package com.my.firstbeat.web.domain.userGenre;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserGenreRepository extends JpaRepository<UserGenre, Long> {
+    List<UserGenre> findByUserId(Long userId);
 }

--- a/src/main/java/com/my/firstbeat/web/domain/userGenre/UserGenreRepository.java
+++ b/src/main/java/com/my/firstbeat/web/domain/userGenre/UserGenreRepository.java
@@ -1,8 +1,12 @@
 package com.my.firstbeat.web.domain.userGenre;
 
 import java.util.List;
+
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface UserGenreRepository extends JpaRepository<UserGenre, Long> {
-    List<UserGenre> findByUserId(Long userId);
+    @Query("SELECT ug FROM UserGenre ug JOIN FETCH ug.genre WHERE ug.user.id = :userId")
+    List<UserGenre> findByUserIdWithGenre(@Param("userId") Long userId);
 }

--- a/src/main/java/com/my/firstbeat/web/dummy/DummyObject.java
+++ b/src/main/java/com/my/firstbeat/web/dummy/DummyObject.java
@@ -1,8 +1,13 @@
 package com.my.firstbeat.web.dummy;
 
+import com.my.firstbeat.web.domain.genre.Genre;
 import com.my.firstbeat.web.domain.user.Role;
 import com.my.firstbeat.web.domain.user.User;
+import com.my.firstbeat.web.domain.userGenre.UserGenre;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class DummyObject {
 
@@ -17,5 +22,20 @@ public class DummyObject {
                 .password(encoder.encode(mockUserPassword))
                 .role(Role.USER)
                 .build();
+    }
+
+    protected List<UserGenre> mockUserGenres(User user) {
+        List<UserGenre> userGenres = new ArrayList<>();
+
+        Genre genre1 = Genre.builder().name("Rock").build();
+        Genre genre2 = Genre.builder().name("Jazz").build();
+
+        UserGenre userGenre1 = UserGenre.builder().user(user).genre(genre1).build();
+        UserGenre userGenre2 = UserGenre.builder().user(user).genre(genre2).build();
+
+        userGenres.add(userGenre1);
+        userGenres.add(userGenre2);
+
+        return userGenres;
     }
 }

--- a/src/main/java/com/my/firstbeat/web/ex/ErrorCode.java
+++ b/src/main/java/com/my/firstbeat/web/ex/ErrorCode.java
@@ -6,8 +6,8 @@ import org.apache.hc.core5.http.HttpStatus;
 @Getter
 public enum ErrorCode {
 
+    USER_NOT_FOUND("Access denied for user data", HttpStatus.SC_FORBIDDEN), // UserId를 통해 해당 유저가 존재하는지 하지 않는지 파악하는것을 막기위해 403 코드로 적용
     DUPLICATE_PLAYLIST_TITLE("이미 존재하는 제목입니다.", HttpStatus.SC_CONFLICT),
-    NotFoundUser("Access denied for user data", 403); // UserId를 통해 해당 유저가 존재하는지 하지 않는지 파악하는것을 막기위해 403 코드로 적용
     ;
 
     private final String message;

--- a/src/main/java/com/my/firstbeat/web/ex/ErrorCode.java
+++ b/src/main/java/com/my/firstbeat/web/ex/ErrorCode.java
@@ -6,7 +6,8 @@ import org.apache.hc.core5.http.HttpStatus;
 @Getter
 public enum ErrorCode {
 
-    DUPLICATE_PLAYLIST_TITLE("이미 존재하는 제목입니다.", HttpStatus.SC_CONFLICT)
+    DUPLICATE_PLAYLIST_TITLE("이미 존재하는 제목입니다.", HttpStatus.SC_CONFLICT),
+    NotFoundUser("Access denied for user data", 403); // UserId를 통해 해당 유저가 존재하는지 하지 않는지 파악하는것을 막기위해 403 코드로 적용
     ;
 
     private final String message;

--- a/src/main/java/com/my/firstbeat/web/service/UserService.java
+++ b/src/main/java/com/my/firstbeat/web/service/UserService.java
@@ -32,7 +32,7 @@ public class UserService {
      */
     public MyPageResponse getUserData(Long userId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.NotFoundUser));
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         List<UserGenre> userGenres = userGenreRepository.findByUserId(userId);
         // 관심 장르 조회

--- a/src/main/java/com/my/firstbeat/web/service/UserService.java
+++ b/src/main/java/com/my/firstbeat/web/service/UserService.java
@@ -35,10 +35,12 @@ public class UserService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.NotFoundUser));
 
         List<UserGenre> userGenres = userGenreRepository.findByUserId(userId);
+        // 관심 장르 조회
         List<String> genres = userGenres.stream()
                 .map(userGenre -> userGenre.getGenre().getName())
                 .collect(Collectors.toList());
 
+        log.info("유저명: {}, 이메일: {}, 관심장르: {}", user.getName(), user.getEmail(), genres);
         return new MyPageResponse(user.getName(), user.getEmail(), genres);
     }
 }

--- a/src/main/java/com/my/firstbeat/web/service/UserService.java
+++ b/src/main/java/com/my/firstbeat/web/service/UserService.java
@@ -34,7 +34,7 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-        List<UserGenre> userGenres = userGenreRepository.findByUserId(userId);
+        List<UserGenre> userGenres = userGenreRepository.findByUserIdWithGenre(userId);
         // 관심 장르 조회
         List<String> genres = userGenres.stream()
                 .map(userGenre -> userGenre.getGenre().getName())

--- a/src/main/java/com/my/firstbeat/web/service/UserService.java
+++ b/src/main/java/com/my/firstbeat/web/service/UserService.java
@@ -1,13 +1,44 @@
 package com.my.firstbeat.web.service;
 
+import com.my.firstbeat.web.controller.user.dto.response.MyPageResponse;
+import com.my.firstbeat.web.domain.user.User;
+import com.my.firstbeat.web.domain.user.UserRepository;
+import com.my.firstbeat.web.domain.userGenre.UserGenre;
+import com.my.firstbeat.web.domain.userGenre.UserGenreRepository;
+import com.my.firstbeat.web.ex.BusinessException;
+import com.my.firstbeat.web.ex.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Slf4j
 public class UserService {
+
+    private final UserRepository userRepository;
+    private final UserGenreRepository userGenreRepository;
+
+    /**
+     * 매개변수로 입력받은 userId에 해당하는 유저명과 이메일, 관심장르를 MyPageResponse 객체에 담아 반환
+     * @param userId 유저명, 이메일, 관심장르를 반환할 유저의 Id
+     * @return MyPageResponse
+     * @exception BusinessException NotFoundUserException
+     */
+    public MyPageResponse getUserData(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NotFoundUser));
+
+        List<UserGenre> userGenres = userGenreRepository.findByUserId(userId);
+        List<String> genres = userGenres.stream()
+                .map(userGenre -> userGenre.getGenre().getName())
+                .collect(Collectors.toList());
+
+        return new MyPageResponse(user.getName(), user.getEmail(), genres);
+    }
 }

--- a/src/test/java/com/my/firstbeat/web/service/UserServiceTest.java
+++ b/src/test/java/com/my/firstbeat/web/service/UserServiceTest.java
@@ -1,0 +1,73 @@
+package com.my.firstbeat.web.service;
+
+import com.my.firstbeat.web.controller.user.dto.response.MyPageResponse;
+import com.my.firstbeat.web.domain.genre.Genre;
+import com.my.firstbeat.web.domain.user.User;
+import com.my.firstbeat.web.domain.user.UserRepository;
+import com.my.firstbeat.web.domain.userGenre.UserGenre;
+import com.my.firstbeat.web.domain.userGenre.UserGenreRepository;
+import com.my.firstbeat.web.dummy.DummyObject;
+import com.my.firstbeat.web.ex.BusinessException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+class UserServiceTest extends DummyObject {
+
+    @InjectMocks
+    private UserService userService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserGenreRepository userGenreRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("마이페이지 조회 성공 테스트")
+    void getUserData_Success() {
+        // Given
+        User mockUser = mockUser();
+        when(userRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+
+        List<UserGenre> userGenres = mockUserGenres(mockUser);
+        when(userGenreRepository.findByUserId(1L)).thenReturn(userGenres);
+
+        // When
+        MyPageResponse response = userService.getUserData(1L);
+
+        // Then
+        assertEquals("test name", response.getName());
+        assertEquals("test1234@naver.com", response.getEmail());
+        assertEquals(List.of("Rock", "Jazz"), response.getGenres());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자를 조회할 경우 테스트")
+    void getUserData_UserNotFound() {
+        // Given
+        when(userRepository.findById(999L)).thenReturn(Optional.empty());
+
+        // When & Then
+        Exception exception = assertThrows(BusinessException.class, () -> {
+            userService.getUserData(999L);
+        });
+
+        assertEquals("Access denied for user data", exception.getMessage());
+    }
+}

--- a/src/test/java/com/my/firstbeat/web/service/UserServiceTest.java
+++ b/src/test/java/com/my/firstbeat/web/service/UserServiceTest.java
@@ -7,6 +7,7 @@ import com.my.firstbeat.web.domain.userGenre.UserGenre;
 import com.my.firstbeat.web.domain.userGenre.UserGenreRepository;
 import com.my.firstbeat.web.dummy.DummyObject;
 import com.my.firstbeat.web.ex.BusinessException;
+import com.my.firstbeat.web.ex.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -45,7 +46,7 @@ class UserServiceTest extends DummyObject {
         when(userRepository.findById(1L)).thenReturn(Optional.of(mockUser));
 
         List<UserGenre> userGenres = mockUserGenres(mockUser);
-        when(userGenreRepository.findByUserId(1L)).thenReturn(userGenres);
+        when(userGenreRepository.findByUserIdWithGenre(1L)).thenReturn(userGenres);
 
         // When
         MyPageResponse response = userService.getUserData(1L);
@@ -63,8 +64,8 @@ class UserServiceTest extends DummyObject {
         when(userRepository.findById(999L)).thenReturn(Optional.empty());
 
         // When & Then
-        Exception exception = assertThrows(BusinessException.class, () -> userService.getUserData(999L));
+        BusinessException exception = assertThrows(BusinessException.class, () -> userService.getUserData(999L));
 
-        assertEquals("Access denied for user data", exception.getMessage());
+        assertEquals(ErrorCode.USER_NOT_FOUND.getMessage(), exception.getMessage());
     }
 }

--- a/src/test/java/com/my/firstbeat/web/service/UserServiceTest.java
+++ b/src/test/java/com/my/firstbeat/web/service/UserServiceTest.java
@@ -1,7 +1,6 @@
 package com.my.firstbeat.web.service;
 
 import com.my.firstbeat.web.controller.user.dto.response.MyPageResponse;
-import com.my.firstbeat.web.domain.genre.Genre;
 import com.my.firstbeat.web.domain.user.User;
 import com.my.firstbeat.web.domain.user.UserRepository;
 import com.my.firstbeat.web.domain.userGenre.UserGenre;
@@ -64,9 +63,7 @@ class UserServiceTest extends DummyObject {
         when(userRepository.findById(999L)).thenReturn(Optional.empty());
 
         // When & Then
-        Exception exception = assertThrows(BusinessException.class, () -> {
-            userService.getUserData(999L);
-        });
+        Exception exception = assertThrows(BusinessException.class, () -> userService.getUserData(999L));
 
         assertEquals("Access denied for user data", exception.getMessage());
     }


### PR DESCRIPTION
### 시나리오
- `/api/v1/users/mypage`
1. 마이페이지 조회 시 요청
2. 사용자 아이디가 DB에 존재할 경우 사용자의 `이름, Email, 관심장르`를 반환
3. 존재하지 않는 사용자 일 경우 403 오류 반환

### 단위 테스트 
- UserServiceTest에서 진행
1. 마이페이지 조회 성공: 정상 케이스
2. 존재하지 않는 사용자 조회