### PR TITLE
마이페이지 수정 기능 구현

### DIFF
--- a/src/main/java/com/my/firstbeat/web/controller/user/UserController.java
+++ b/src/main/java/com/my/firstbeat/web/controller/user/UserController.java
@@ -1,7 +1,7 @@
 package com.my.firstbeat.web.controller.user;
 
 import com.my.firstbeat.web.config.security.loginuser.LoginUser;
-import com.my.firstbeat.web.controller.user.dto.response.MyPageResponse;
+import com.my.firstbeat.web.controller.user.dto.response.GetMyPageResponse;
 import com.my.firstbeat.web.service.UserService;
 import com.my.firstbeat.web.util.api.ApiResult;
 import lombok.RequiredArgsConstructor;
@@ -19,10 +19,10 @@ public class UserController {
     private final UserService userService;
 
     @GetMapping("/mypage")
-    public ResponseEntity<ApiResult<MyPageResponse>> getMyPage(@AuthenticationPrincipal LoginUser loginUser) {
+    public ResponseEntity<ApiResult<GetMyPageResponse>> getMyPage(@AuthenticationPrincipal LoginUser loginUser) {
         Long userId = loginUser.getUser().getId();
 
-        MyPageResponse response = userService.getUserData(userId);
+        GetMyPageResponse response = userService.getUserData(userId);
 
         return ResponseEntity.ok(ApiResult.success(response));
     }

--- a/src/main/java/com/my/firstbeat/web/controller/user/UserController.java
+++ b/src/main/java/com/my/firstbeat/web/controller/user/UserController.java
@@ -6,6 +6,7 @@ import com.my.firstbeat.web.controller.user.dto.response.GetMyPageResponse;
 import com.my.firstbeat.web.controller.user.dto.response.UpdateMyPageResponse;
 import com.my.firstbeat.web.service.UserService;
 import com.my.firstbeat.web.util.api.ApiResult;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -30,9 +31,9 @@ public class UserController {
     @PatchMapping("/mypage")
     public ResponseEntity<ApiResult<UpdateMyPageResponse>> updateMyPage(
             @AuthenticationPrincipal LoginUser loginUser,
-            @RequestBody UpdateMyPageRequest request
-    ) {
-        UpdateMyPageResponse response = userService.updateMyPage(loginUser.getUser().getId(), request);
+            @RequestBody @Valid UpdateMyPageRequest request) {
+        Long userId = loginUser.getUser().getId();
+        UpdateMyPageResponse response = userService.updateMyPage(userId, request);
         return ResponseEntity.ok(ApiResult.success(response));
     }
 }

--- a/src/main/java/com/my/firstbeat/web/controller/user/UserController.java
+++ b/src/main/java/com/my/firstbeat/web/controller/user/UserController.java
@@ -1,15 +1,15 @@
 package com.my.firstbeat.web.controller.user;
 
 import com.my.firstbeat.web.config.security.loginuser.LoginUser;
+import com.my.firstbeat.web.controller.user.dto.request.UpdateMyPageRequest;
 import com.my.firstbeat.web.controller.user.dto.response.GetMyPageResponse;
+import com.my.firstbeat.web.controller.user.dto.response.UpdateMyPageResponse;
 import com.my.firstbeat.web.service.UserService;
 import com.my.firstbeat.web.util.api.ApiResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,6 +24,15 @@ public class UserController {
 
         GetMyPageResponse response = userService.getUserData(userId);
 
+        return ResponseEntity.ok(ApiResult.success(response));
+    }
+
+    @PatchMapping("/mypage")
+    public ResponseEntity<ApiResult<UpdateMyPageResponse>> updateMyPage(
+            @AuthenticationPrincipal LoginUser loginUser,
+            @RequestBody UpdateMyPageRequest request
+    ) {
+        UpdateMyPageResponse response = userService.updateMyPage(loginUser.getUser().getId(), request);
         return ResponseEntity.ok(ApiResult.success(response));
     }
 }

--- a/src/main/java/com/my/firstbeat/web/controller/user/dto/request/UpdateMyPageRequest.java
+++ b/src/main/java/com/my/firstbeat/web/controller/user/dto/request/UpdateMyPageRequest.java
@@ -1,16 +1,21 @@
 package com.my.firstbeat.web.controller.user.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.List;
-import java.util.Optional;
 
 @Getter
 @Setter
 @NoArgsConstructor
 public class UpdateMyPageRequest {
-    private Optional<String> name = Optional.empty();
-    private Optional<List<String>> favoriteGenre = Optional.empty();
+
+    @NotBlank(message = "Name cannot be blank")
+    private String name;
+
+    @NotEmpty(message = "Favorite genres cannot be empty")
+    private List<String> favoriteGenre;
 }

--- a/src/main/java/com/my/firstbeat/web/controller/user/dto/request/UpdateMyPageRequest.java
+++ b/src/main/java/com/my/firstbeat/web/controller/user/dto/request/UpdateMyPageRequest.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.util.List;
+import java.util.Set;
 
 @Getter
 @Setter
@@ -19,5 +19,5 @@ public class UpdateMyPageRequest {
     private String name;
 
     @NotEmpty(message = "Favorite genres cannot be empty")
-    private List<String> favoriteGenre;
+    private Set<String> favoriteGenre;
 }

--- a/src/main/java/com/my/firstbeat/web/controller/user/dto/request/UpdateMyPageRequest.java
+++ b/src/main/java/com/my/firstbeat/web/controller/user/dto/request/UpdateMyPageRequest.java
@@ -1,0 +1,16 @@
+package com.my.firstbeat.web.controller.user.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+import java.util.Optional;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class UpdateMyPageRequest {
+    private Optional<String> name = Optional.empty();
+    private Optional<List<String>> favoriteGenre = Optional.empty();
+}

--- a/src/main/java/com/my/firstbeat/web/controller/user/dto/request/UpdateMyPageRequest.java
+++ b/src/main/java/com/my/firstbeat/web/controller/user/dto/request/UpdateMyPageRequest.java
@@ -2,6 +2,7 @@ package com.my.firstbeat.web.controller.user.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -14,6 +15,7 @@ import java.util.List;
 public class UpdateMyPageRequest {
 
     @NotBlank(message = "Name cannot be blank")
+    @Size(min = 1, max = 2147483647, message = "Name must be at least 1 character")
     private String name;
 
     @NotEmpty(message = "Favorite genres cannot be empty")

--- a/src/main/java/com/my/firstbeat/web/controller/user/dto/response/GetMyPageResponse.java
+++ b/src/main/java/com/my/firstbeat/web/controller/user/dto/response/GetMyPageResponse.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 @Getter
 @AllArgsConstructor
-public class MyPageResponse {
+public class GetMyPageResponse {
     private String name;
     private String email;
     private List<String> genres;

--- a/src/main/java/com/my/firstbeat/web/controller/user/dto/response/UpdateMyPageResponse.java
+++ b/src/main/java/com/my/firstbeat/web/controller/user/dto/response/UpdateMyPageResponse.java
@@ -1,0 +1,14 @@
+package com.my.firstbeat.web.controller.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Set;
+
+@Getter
+@AllArgsConstructor
+public class UpdateMyPageResponse {
+    private String name;
+    private String email;
+    private Set<String> favoriteGenre;
+}

--- a/src/main/java/com/my/firstbeat/web/domain/genre/GenreRepository.java
+++ b/src/main/java/com/my/firstbeat/web/domain/genre/GenreRepository.java
@@ -1,14 +1,17 @@
 package com.my.firstbeat.web.domain.genre;
 
 import com.my.firstbeat.web.domain.user.User;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
+import java.util.Set;
 import java.util.List;
 
 public interface GenreRepository extends JpaRepository<Genre, Long> {
+    @Query("SELECT g.id FROM Genre g WHERE g.name IN :names")
+    Set<Long> findIdsByNames(@Param("names") Set<String> names);
 
     @Query("select g from Genre g join UserGenre ug on ug.genre = g where ug.user = :user")
     List<Genre> findTop5GenresByUser(@Param("user") User user, Pageable pageable);

--- a/src/main/java/com/my/firstbeat/web/domain/user/User.java
+++ b/src/main/java/com/my/firstbeat/web/domain/user/User.java
@@ -6,6 +6,7 @@ import lombok.*;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "users")
 @AllArgsConstructor

--- a/src/main/java/com/my/firstbeat/web/domain/userGenre/UserGenreRepository.java
+++ b/src/main/java/com/my/firstbeat/web/domain/userGenre/UserGenreRepository.java
@@ -1,14 +1,17 @@
 package com.my.firstbeat.web.domain.userGenre;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
 import java.util.List;
 
+import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface UserGenreRepository extends JpaRepository<UserGenre, Long> {
     @Query("SELECT ug FROM UserGenre ug JOIN FETCH ug.genre WHERE ug.user.id = :userId")
     List<UserGenre> findByUserIdWithGenre(@Param("userId") Long userId);
 
+    @Modifying
+    @Query("DELETE FROM UserGenre ug WHERE ug.user.id = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/my/firstbeat/web/dummy/DummyObject.java
+++ b/src/main/java/com/my/firstbeat/web/dummy/DummyObject.java
@@ -51,7 +51,7 @@ public class DummyObject {
         List<UserGenre> userGenres = new ArrayList<>();
 
         Genre genre1 = Genre.builder().name("Rock").build();
-        Genre genre2 = Genre.builder().name("Jazz").build();
+        Genre genre2 = Genre.builder().name("Pop").build();
 
         UserGenre userGenre1 = UserGenre.builder().user(user).genre(genre1).build();
         UserGenre userGenre2 = UserGenre.builder().user(user).genre(genre2).build();

--- a/src/main/java/com/my/firstbeat/web/service/UserService.java
+++ b/src/main/java/com/my/firstbeat/web/service/UserService.java
@@ -1,6 +1,5 @@
 package com.my.firstbeat.web.service;
 
-import com.my.firstbeat.web.config.security.loginuser.LoginUser;
 import com.my.firstbeat.web.controller.user.dto.request.UpdateMyPageRequest;
 import com.my.firstbeat.web.controller.user.dto.response.GetMyPageResponse;
 import com.my.firstbeat.web.controller.user.dto.response.UpdateMyPageResponse;

--- a/src/main/java/com/my/firstbeat/web/service/UserService.java
+++ b/src/main/java/com/my/firstbeat/web/service/UserService.java
@@ -1,5 +1,6 @@
 package com.my.firstbeat.web.service;
 
+import com.my.firstbeat.web.controller.user.dto.response.GetMyPageResponse;
 import com.my.firstbeat.web.domain.user.User;
 import com.my.firstbeat.web.domain.user.UserRepository;
 import com.my.firstbeat.web.controller.user.dto.response.MyPageResponse;
@@ -36,7 +37,7 @@ public class UserService {
      * @return MyPageResponse
      * @exception BusinessException NotFoundUserException
      */
-    public MyPageResponse getUserData(Long userId) {
+    public GetMyPageResponse getUserData(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
@@ -47,6 +48,6 @@ public class UserService {
                 .collect(Collectors.toList());
 
         log.info("유저명: {}, 이메일: {}, 관심장르: {}", user.getName(), user.getEmail(), genres);
-        return new MyPageResponse(user.getName(), user.getEmail(), genres);
+        return new GetMyPageResponse(user.getName(), user.getEmail(), genres);
     }
 }

--- a/src/main/java/com/my/firstbeat/web/service/UserService.java
+++ b/src/main/java/com/my/firstbeat/web/service/UserService.java
@@ -15,7 +15,6 @@ import com.my.firstbeat.web.ex.BusinessException;
 import com.my.firstbeat.web.ex.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -72,16 +71,16 @@ public class UserService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         // 이름 업데이트
-        request.getName().ifPresent(user::setName);
-        userRepository.save(user);
+        if (request.getName() != null) {
+            user.setName(request.getName());
+            userRepository.save(user);
+        }
 
         // 관심 장르 업데이트
-        request.getFavoriteGenre().ifPresent(favoriteGenres -> {
-            // 기존 장르 삭제
+        if (request.getFavoriteGenre() != null && !request.getFavoriteGenre().isEmpty()) {
             userGenreRepository.deleteByUserId(userId);
 
-            // 새로운 장르 추가
-            List<Genre> genres = genreRepository.findByNameIn(favoriteGenres);
+            List<Genre> genres = genreRepository.findByNameIn(request.getFavoriteGenre());
             for (Genre genre : genres) {
                 UserGenre userGenre = UserGenre.builder()
                         .user(user)
@@ -89,7 +88,7 @@ public class UserService {
                         .build();
                 userGenreRepository.save(userGenre);
             }
-        });
+        }
 
         // 업데이트된 장르 조회
         List<UserGenre> updatedUserGenres = userGenreRepository.findByUserIdWithGenre(userId);

--- a/src/main/java/com/my/firstbeat/web/service/UserService.java
+++ b/src/main/java/com/my/firstbeat/web/service/UserService.java
@@ -1,6 +1,11 @@
 package com.my.firstbeat.web.service;
 
+import com.my.firstbeat.web.config.security.loginuser.LoginUser;
+import com.my.firstbeat.web.controller.user.dto.request.UpdateMyPageRequest;
 import com.my.firstbeat.web.controller.user.dto.response.GetMyPageResponse;
+import com.my.firstbeat.web.controller.user.dto.response.UpdateMyPageResponse;
+import com.my.firstbeat.web.domain.genre.Genre;
+import com.my.firstbeat.web.domain.genre.GenreRepository;
 import com.my.firstbeat.web.domain.user.User;
 import com.my.firstbeat.web.domain.user.UserRepository;
 import com.my.firstbeat.web.controller.user.dto.response.MyPageResponse;
@@ -10,10 +15,12 @@ import com.my.firstbeat.web.ex.BusinessException;
 import com.my.firstbeat.web.ex.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -24,6 +31,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final UserGenreRepository userGenreRepository;
+    private final GenreRepository genreRepository; // GenreRepository 추가
 
 
     public User findByIdOrFail(Long id) {
@@ -49,5 +57,48 @@ public class UserService {
 
         log.info("유저명: {}, 이메일: {}, 관심장르: {}", user.getName(), user.getEmail(), genres);
         return new GetMyPageResponse(user.getName(), user.getEmail(), genres);
+    }
+
+    /**
+     * 매개변수로 입력받은 userId에 해당하는 유저 정보를 반환한 후 닉네임과 관심장르를 수정
+     * @param userId 유저 정보를 반환할 유저의 Id
+     * @param request {"name": "test", "favoriteGenre": {"genre1", "genre2", "genre3"}}
+     * @return UpdateMyPageResponse
+     * @exception BusinessException USER_NOT_FOUND
+     */
+    @Transactional
+    public UpdateMyPageResponse updateMyPage(Long userId, UpdateMyPageRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        // 이름 업데이트
+        request.getName().ifPresent(user::setName);
+        userRepository.save(user);
+
+        // 관심 장르 업데이트
+        request.getFavoriteGenre().ifPresent(favoriteGenres -> {
+            // 기존 장르 삭제
+            userGenreRepository.deleteByUserId(userId);
+
+            // 새로운 장르 추가
+            List<Genre> genres = genreRepository.findByNameIn(favoriteGenres);
+            for (Genre genre : genres) {
+                UserGenre userGenre = UserGenre.builder()
+                        .user(user)
+                        .genre(genre)
+                        .build();
+                userGenreRepository.save(userGenre);
+            }
+        });
+
+        // 업데이트된 장르 조회
+        List<UserGenre> updatedUserGenres = userGenreRepository.findByUserIdWithGenre(userId);
+        Set<String> updatedGenres = updatedUserGenres.stream()
+                .map(userGenre -> userGenre.getGenre().getName())
+                .collect(Collectors.toSet());
+
+        log.info("유저명: {}, 관심 장르: {}", user.getName(), updatedGenres);
+
+        return new UpdateMyPageResponse(user.getName(), user.getEmail(), updatedGenres);
     }
 }

--- a/src/main/java/com/my/firstbeat/web/service/UserService.java
+++ b/src/main/java/com/my/firstbeat/web/service/UserService.java
@@ -8,7 +8,6 @@ import com.my.firstbeat.web.domain.genre.Genre;
 import com.my.firstbeat.web.domain.genre.GenreRepository;
 import com.my.firstbeat.web.domain.user.User;
 import com.my.firstbeat.web.domain.user.UserRepository;
-import com.my.firstbeat.web.controller.user.dto.response.MyPageResponse;
 import com.my.firstbeat.web.domain.userGenre.UserGenre;
 import com.my.firstbeat.web.domain.userGenre.UserGenreRepository;
 import com.my.firstbeat.web.ex.BusinessException;

--- a/src/test/java/com/my/firstbeat/web/service/UserServiceTest.java
+++ b/src/test/java/com/my/firstbeat/web/service/UserServiceTest.java
@@ -85,8 +85,8 @@ class UserServiceTest extends DummyObject {
         when(userRepository.findById(1L)).thenReturn(Optional.of(mockUser));
 
         UpdateMyPageRequest request = new UpdateMyPageRequest();
-        request.setName(Optional.of("updatedName"));
-        request.setFavoriteGenre(Optional.of(List.of("Jazz", "Rock")));
+        request.setName("updatedName");
+        request.setFavoriteGenre(List.of("Jazz", "Rock"));
 
         Genre jazz = Genre.builder().name("Jazz").build();
         Genre rock = Genre.builder().name("Rock").build();

--- a/src/test/java/com/my/firstbeat/web/service/UserServiceTest.java
+++ b/src/test/java/com/my/firstbeat/web/service/UserServiceTest.java
@@ -1,6 +1,6 @@
 package com.my.firstbeat.web.service;
 
-import com.my.firstbeat.web.controller.user.dto.response.MyPageResponse;
+import com.my.firstbeat.web.controller.user.dto.response.GetMyPageResponse;
 import com.my.firstbeat.web.domain.user.User;
 import com.my.firstbeat.web.domain.user.UserRepository;
 import com.my.firstbeat.web.domain.userGenre.UserGenre;
@@ -49,7 +49,7 @@ class UserServiceTest extends DummyObject {
         when(userGenreRepository.findByUserIdWithGenre(1L)).thenReturn(userGenres);
 
         // When
-        MyPageResponse response = userService.getUserData(1L);
+        GetMyPageResponse response = userService.getUserData(1L);
 
         // Then
         assertEquals("test name", response.getName());


### PR DESCRIPTION
### 시나리오
- `PETCH` `/api/v1/users/mypage`
1. 마이페이지 수정 시 요청
2. 사용자 아이디가 DB에 존재할 경우 요청한 사용자의 이름과 관심장르를 수정 후 저장
3. 존재하지 않는 사용자 일 경우 403 오류 반환

### 단위 테스트 
- UserServiceTest에서 진행
1. 마이페이지 수정 성공: 정상 케이스
2. 존재하지 않는 사용자 조회 403 오류 반환