### PR TITLE
v1: 추천 시스템의 성능 최적화와 동시성 제어를 위한 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,8 @@ dependencies {
 
     //cache
     implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
+
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    //cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/my/firstbeat/client/spotify/SpotifyClient.java
+++ b/src/main/java/com/my/firstbeat/client/spotify/SpotifyClient.java
@@ -1,5 +1,6 @@
 package com.my.firstbeat.client.spotify;
 
+import com.my.firstbeat.client.spotify.dto.response.RecommendationResponse;
 import com.my.firstbeat.client.spotify.dto.response.TrackSearchResponse;
 import com.my.firstbeat.client.spotify.ex.SpotifyApiException;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +10,7 @@ import org.springframework.stereotype.Service;
 import se.michaelthelin.spotify.SpotifyApi;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.model_objects.specification.Paging;
+import se.michaelthelin.spotify.model_objects.specification.Recommendations;
 import se.michaelthelin.spotify.model_objects.specification.Track;
 
 import java.io.IOException;
@@ -42,6 +44,22 @@ public class SpotifyClient {
                     .execute();
             log.debug("Spotify API 호출 완료 - getGenreList, size: {}", genres.length);
             return genres;
+        });
+    }
+
+    //추천 트랙 리스트 조회
+    public RecommendationResponse getRecommendations(String seedTracks, String seedGenres, int limit){
+        return executeWithValidToken(() -> {
+            Recommendations recommendations = spotifyApi.getRecommendations()
+                    .limit(limit)
+                    .target_popularity(50)
+                    .min_popularity(20)
+                    .max_popularity(100)
+                    .seed_genres(seedGenres)
+                    .seed_tracks(seedTracks)
+                    .build()
+                    .execute();
+            return new RecommendationResponse(recommendations);
         });
     }
 

--- a/src/main/java/com/my/firstbeat/client/spotify/dto/response/RecommendationResponse.java
+++ b/src/main/java/com/my/firstbeat/client/spotify/dto/response/RecommendationResponse.java
@@ -1,0 +1,26 @@
+package com.my.spotify.client.spotify.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import se.michaelthelin.spotify.model_objects.specification.Recommendations;
+import se.michaelthelin.spotify.model_objects.specification.RecommendationsSeed;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.my.spotify.client.spotify.dto.SearchRespDto.*;
+
+@NoArgsConstructor
+@Getter
+public class RecommendationRespDto {
+
+    private RecommendationsSeed[] seeds;
+    private Integer total;
+    private List<TestTrackRespDto> tracks;
+
+    public RecommendationRespDto(Recommendations recommendations) {
+        this.seeds = recommendations.getSeeds();
+        this.tracks = Arrays.stream(recommendations.getTracks()).map(TestTrackRespDto::new).toList();
+        this.total = tracks.size();
+    }
+}

--- a/src/main/java/com/my/firstbeat/client/spotify/dto/response/RecommendationResponse.java
+++ b/src/main/java/com/my/firstbeat/client/spotify/dto/response/RecommendationResponse.java
@@ -1,4 +1,4 @@
-package com.my.spotify.client.spotify.dto;
+package com.my.firstbeat.client.spotify.dto.response;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,19 +8,20 @@ import se.michaelthelin.spotify.model_objects.specification.RecommendationsSeed;
 import java.util.Arrays;
 import java.util.List;
 
-import static com.my.spotify.client.spotify.dto.SearchRespDto.*;
+import static com.my.firstbeat.client.spotify.dto.response.TrackSearchResponse.*;
+
 
 @NoArgsConstructor
 @Getter
-public class RecommendationRespDto {
+public class RecommendationResponse {
 
     private RecommendationsSeed[] seeds;
     private Integer total;
-    private List<TestTrackRespDto> tracks;
+    private List<TrackResponse> tracks;
 
-    public RecommendationRespDto(Recommendations recommendations) {
+    public RecommendationResponse(Recommendations recommendations) {
         this.seeds = recommendations.getSeeds();
-        this.tracks = Arrays.stream(recommendations.getTracks()).map(TestTrackRespDto::new).toList();
+        this.tracks = Arrays.stream(recommendations.getTracks()).map(TrackResponse::new).toList();
         this.total = tracks.size();
     }
 }

--- a/src/main/java/com/my/firstbeat/client/spotify/dto/response/RecommendationResponse.java
+++ b/src/main/java/com/my/firstbeat/client/spotify/dto/response/RecommendationResponse.java
@@ -2,6 +2,7 @@ package com.my.firstbeat.client.spotify.dto.response;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import se.michaelthelin.spotify.model_objects.specification.Recommendations;
 import se.michaelthelin.spotify.model_objects.specification.RecommendationsSeed;
 
@@ -13,6 +14,7 @@ import static com.my.firstbeat.client.spotify.dto.response.TrackSearchResponse.*
 
 @NoArgsConstructor
 @Getter
+@Setter
 public class RecommendationResponse {
 
     private RecommendationsSeed[] seeds;

--- a/src/main/java/com/my/firstbeat/client/spotify/dto/response/TrackSearchResponse.java
+++ b/src/main/java/com/my/firstbeat/client/spotify/dto/response/TrackSearchResponse.java
@@ -22,7 +22,7 @@ public class TrackSearchResponse {
     private String next;
     private String previous;
     private Integer total;
-    private List<TestTrackRespDto> tracks;
+    private List<TrackResponse> tracks;
 
 
     public TrackSearchResponse(Paging<Track> trackPage) {
@@ -30,40 +30,40 @@ public class TrackSearchResponse {
         next = trackPage.getNext();
         previous = trackPage.getPrevious();
         total = trackPage.getTotal();
-        tracks = Arrays.stream(trackPage.getItems()).map(TestTrackRespDto::new).toList();
+        tracks = Arrays.stream(trackPage.getItems()).map(TrackResponse::new).toList();
     }
 
     @NoArgsConstructor
     @Getter
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-    public static class TestTrackRespDto{
+    public static class TrackResponse {
         private String trackName;
         private String id;
         private Boolean isPlayable;
         private String previewUrl;
-        private ArtistRespDto artists;
-        private String uri;
+        private ArtistResponse artists;
         private String name;
+        private String albumCoverUrl;
 
 
-        public TestTrackRespDto(Track track) {
+        public TrackResponse(Track track) {
             AlbumSimplified album = track.getAlbum();
             this.id = album.getId();
             this.isPlayable = track.getIsPlayable();
             this.previewUrl = track.getPreviewUrl();
-            this.artists = new ArtistRespDto(album.getArtists());
-            this.uri = track.getUri();
+            this.artists = new ArtistResponse(album.getArtists());
             this.name = album.getName();
             this.trackName = track.getName();
+            this.albumCoverUrl = Arrays.stream(album.getImages()).toList().get(0).getUrl();
         }
 
         @NoArgsConstructor
         @Getter
         @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-        public static class ArtistRespDto{
+        public static class ArtistResponse {
             private String name;
 
-            public ArtistRespDto(ArtistSimplified[] artistSimplified) {
+            public ArtistResponse(ArtistSimplified[] artistSimplified) {
                 this.name = artistSimplified[0].getName();
             }
         }

--- a/src/main/java/com/my/firstbeat/client/spotify/dto/response/TrackSearchResponse.java
+++ b/src/main/java/com/my/firstbeat/client/spotify/dto/response/TrackSearchResponse.java
@@ -2,6 +2,8 @@ package com.my.firstbeat.client.spotify.dto.response;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import se.michaelthelin.spotify.model_objects.specification.AlbumSimplified;
@@ -36,6 +38,8 @@ public class TrackSearchResponse {
     @NoArgsConstructor
     @Getter
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    @AllArgsConstructor
+    @Builder
     public static class TrackResponse {
         private String trackName;
         private String id;
@@ -60,6 +64,7 @@ public class TrackSearchResponse {
         @NoArgsConstructor
         @Getter
         @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+        @AllArgsConstructor
         public static class ArtistResponse {
             private String name;
 

--- a/src/main/java/com/my/firstbeat/web/config/cache/CacheConfig.java
+++ b/src/main/java/com/my/firstbeat/web/config/cache/CacheConfig.java
@@ -1,2 +1,34 @@
-package com.my.firstbeat.web.config.cache;public class CacheConfig {
+package com.my.firstbeat.web.config.cache;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.my.firstbeat.web.controller.track.dto.response.TrackRecommendationResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Queue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+
+@Configuration
+@EnableCaching
+@Slf4j
+public class CacheConfig {
+
+    @Bean
+    public Cache<Long, Queue<TrackRecommendationResponse>> recommendationsCache()  {
+        return Caffeine.newBuilder()
+                .expireAfterWrite(24, TimeUnit.HOURS)
+                .expireAfterAccess(6, TimeUnit.HOURS)
+                .maximumSize(10000)
+                .recordStats()
+                .removalListener((key, value, cause) ->
+                        log.info("캐시 삭제 - Key: {}, Cause: {}", key, cause))
+                .build();
+    }
+
 }

--- a/src/main/java/com/my/firstbeat/web/config/cache/CacheConfig.java
+++ b/src/main/java/com/my/firstbeat/web/config/cache/CacheConfig.java
@@ -1,0 +1,2 @@
+package com.my.firstbeat.web.config.cache;public class CacheConfig {
+}

--- a/src/main/java/com/my/firstbeat/web/controller/track/TrackController.java
+++ b/src/main/java/com/my/firstbeat/web/controller/track/TrackController.java
@@ -2,6 +2,7 @@ package com.my.firstbeat.web.controller.track;
 
 import com.my.firstbeat.web.config.security.loginuser.LoginUser;
 import com.my.firstbeat.web.controller.track.dto.response.TrackRecommendationResponse;
+import com.my.firstbeat.web.service.RecommendationService;
 import com.my.firstbeat.web.service.TrackService;
 import com.my.firstbeat.web.util.api.ApiResult;
 import lombok.RequiredArgsConstructor;
@@ -16,11 +17,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1")
 public class TrackController {
 
-    private final TrackService trackService;
+    private final RecommendationService recommendationService;
 
     @GetMapping("/tracks/recommendations")
     public ResponseEntity<ApiResult<TrackRecommendationResponse>> getRecommendations(
             @AuthenticationPrincipal LoginUser loginUser){
-        return ResponseEntity.ok(ApiResult.success(trackService.getRecommendations(loginUser.getUser().getId())));
+        return ResponseEntity.ok(ApiResult.success(recommendationService.getRecommendations(loginUser.getUser().getId())));
     }
 }

--- a/src/main/java/com/my/firstbeat/web/controller/track/TrackController.java
+++ b/src/main/java/com/my/firstbeat/web/controller/track/TrackController.java
@@ -1,9 +1,26 @@
 package com.my.firstbeat.web.controller.track;
 
+import com.my.firstbeat.web.config.security.loginuser.LoginUser;
+import com.my.firstbeat.web.controller.track.dto.response.TrackRecommendationResponse;
+import com.my.firstbeat.web.service.TrackService;
+import com.my.firstbeat.web.util.api.ApiResult;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/v1")
 public class TrackController {
+
+    private final TrackService trackService;
+
+    @GetMapping("/tracks/recommendations")
+    public ResponseEntity<ApiResult<TrackRecommendationResponse>> getRecommendations(
+            @AuthenticationPrincipal LoginUser loginUser){
+        return ResponseEntity.ok(ApiResult.success(trackService.getRecommendations(loginUser.getUser().getId())));
+    }
 }

--- a/src/main/java/com/my/firstbeat/web/controller/track/dto/response/TrackRecommendationResponse.java
+++ b/src/main/java/com/my/firstbeat/web/controller/track/dto/response/TrackRecommendationResponse.java
@@ -1,11 +1,14 @@
 package com.my.firstbeat.web.controller.track.dto.response;
 
+import com.my.firstbeat.client.spotify.dto.response.TrackSearchResponse;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import static com.my.firstbeat.client.spotify.dto.response.TrackSearchResponse.*;
+
 @NoArgsConstructor
 @Getter
-public class TrackRecommendationsResponse {
+public class TrackRecommendationResponse {
 
     private String spotifyTrackId; //스포티파이 트랙 아이디
     private String name; //곡 제목
@@ -13,4 +16,12 @@ public class TrackRecommendationsResponse {
     private String albumCoverUrl; //앨범 커버 url
     private String artistName; //가수 이름
 
+
+    public TrackRecommendationResponse(TrackResponse trackResponse) {
+        this.spotifyTrackId = trackResponse.getId();
+        this.name = trackResponse.getTrackName();
+        this.previewUrl = trackResponse.getPreviewUrl();
+        this.albumCoverUrl = trackResponse.getAlbumCoverUrl();
+        this.artistName = trackResponse.getArtists().getName();
+    }
 }

--- a/src/main/java/com/my/firstbeat/web/controller/track/dto/response/TrackRecommendationResponse.java
+++ b/src/main/java/com/my/firstbeat/web/controller/track/dto/response/TrackRecommendationResponse.java
@@ -1,0 +1,16 @@
+package com.my.firstbeat.web.controller.track.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class TrackRecommendationsResponse {
+
+    private String spotifyTrackId; //스포티파이 트랙 아이디
+    private String name; //곡 제목
+    private String previewUrl; //프리뷰 url
+    private String albumCoverUrl; //앨범 커버 url
+    private String artistName; //가수 이름
+
+}

--- a/src/main/java/com/my/firstbeat/web/domain/playlist/PlaylistRepository.java
+++ b/src/main/java/com/my/firstbeat/web/domain/playlist/PlaylistRepository.java
@@ -4,6 +4,8 @@ package com.my.firstbeat.web.domain.playlist;
 import com.my.firstbeat.web.domain.track.Track;
 import com.my.firstbeat.web.domain.user.User;
 import java.util.Optional;
+
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,10 +17,11 @@ public interface PlaylistRepository extends JpaRepository<Playlist, Long> {
 
 
     @Query("select t from Playlist p " +
-            "left join PlaylistTrack pt on pt.playlist = p " +
-            "left join Track t on pt.track = t " +
-            "where p.user = :user")
-    List<Track> findAllTrackByUser (@Param("user") User user);
+            "join PlaylistTrack pt on pt.playlist = p " +
+            "join Track t on pt.track = t " +
+            "where p.user = :user " +
+            "order by function('random') ")
+    List<Track> findAllTrackByUser (@Param("user") User user, Pageable pageable);
 
 	//특정 사용자의 디폴트 플레이리스트 조회
 	Optional<Playlist> findByUserIdAndIsDefault(Long userId, boolean isDefault);

--- a/src/main/java/com/my/firstbeat/web/domain/playlist/PlaylistRepository.java
+++ b/src/main/java/com/my/firstbeat/web/domain/playlist/PlaylistRepository.java
@@ -1,6 +1,19 @@
 package com.my.firstbeat.web.domain.playlist;
 
+import com.my.firstbeat.web.domain.track.Track;
+import com.my.firstbeat.web.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.security.core.parameters.P;
+
+import java.util.List;
 
 public interface PlaylistRepository extends JpaRepository<Playlist, Long> {
+
+    @Query("select t from Playlist p " +
+            "left join PlaylistTrack pt on pt.playlist = p " +
+            "left join Track t on pt.track = t " +
+            "where p.user = :user")
+    List<Track> findAllTrackByUser (@Param("user") User user);
 }

--- a/src/main/java/com/my/firstbeat/web/domain/track/Track.java
+++ b/src/main/java/com/my/firstbeat/web/domain/track/Track.java
@@ -2,14 +2,14 @@ package com.my.firstbeat.web.domain.track;
 
 import com.my.firstbeat.web.domain.base.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.Columns;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class Track extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/my/firstbeat/web/domain/track/TrackRepository.java
+++ b/src/main/java/com/my/firstbeat/web/domain/track/TrackRepository.java
@@ -1,6 +1,17 @@
 package com.my.firstbeat.web.domain.track;
 
+import com.my.firstbeat.web.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TrackRepository extends JpaRepository<Track, Long> {
+
+
+    @Query("select case when count(t) > 0 then true else false end " +
+            "from Track t " +
+            "join PlaylistTrack pt on pt.track = t " +
+            "join Playlist p on pt.playlist = p " +
+            "where p.user = :user and t.spotifyTrackId = :spotifyTrackId")
+    boolean existsInUserPlaylist(@Param("user") User user, String spotifyTrackId);
 }

--- a/src/main/java/com/my/firstbeat/web/domain/userGenre/UserGenreRepository.java
+++ b/src/main/java/com/my/firstbeat/web/domain/userGenre/UserGenreRepository.java
@@ -1,6 +1,15 @@
 package com.my.firstbeat.web.domain.userGenre;
 
+import com.my.firstbeat.web.domain.genre.Genre;
+import com.my.firstbeat.web.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface UserGenreRepository extends JpaRepository<UserGenre, Long> {
+
+    @Query("select g from UserGenre ug left join fetch ug.genre g where ug.user = :user limit 5")
+    List<Genre> findTop5GenresByUser(@Param("user") User user);
 }

--- a/src/main/java/com/my/firstbeat/web/dummy/DummyObject.java
+++ b/src/main/java/com/my/firstbeat/web/dummy/DummyObject.java
@@ -13,6 +13,18 @@ public class DummyObject {
 
     protected String mockUserPassword = "test1234";
 
+    protected User mockUserWithId(){
+        BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+
+        return User.builder()
+                .id(1L)
+                .name("test name")
+                .email("test1234@naver.com")
+                .password(encoder.encode(mockUserPassword))
+                .role(Role.USER)
+                .build();
+    }
+
     protected User mockUser(){
         BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
 

--- a/src/main/java/com/my/firstbeat/web/ex/ErrorCode.java
+++ b/src/main/java/com/my/firstbeat/web/ex/ErrorCode.java
@@ -1,10 +1,20 @@
 package com.my.firstbeat.web.ex;
 
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ErrorCode {
+    USER_NOT_FOUNT("존재하지 않는 사용자입니다", HttpStatus.NOT_FOUND.value()),
+    FAIL_TO_GET_RECOMMENDATION("추천 트랙을 가져오는데 실패했습니다", HttpStatus.NO_CONTENT.value()),
+    GENRES_NOT_FOUND("사용자의 선호 장르가 존재하지 않습니다", HttpStatus.NOT_FOUND.value()),
+    NO_NEW_RECOMMENDATIONS_AVAILABLE("현재 추천 가능한 새로운 곡이 없습니다. 잠시 후 다시 시도해주세요", HttpStatus.NOT_FOUND.value())
+
+
     ;
+
+
+
     private final String message;
     private final int status;
 

--- a/src/main/java/com/my/firstbeat/web/ex/ErrorCode.java
+++ b/src/main/java/com/my/firstbeat/web/ex/ErrorCode.java
@@ -9,7 +9,9 @@ public enum ErrorCode {
     FAIL_TO_GET_RECOMMENDATION("추천 트랙을 가져오는데 실패했습니다", HttpStatus.NO_CONTENT.value()),
     GENRES_NOT_FOUND("사용자의 선호 장르가 존재하지 않습니다", HttpStatus.NOT_FOUND.value()),
     NO_NEW_RECOMMENDATIONS_AVAILABLE("현재 추천 가능한 새로운 곡이 없습니다. 잠시 후 다시 시도해주세요", HttpStatus.NOT_FOUND.value()),
-    DUPLICATE_PLAYLIST_TITLE("이미 존재하는 제목입니다.", HttpStatus.CONFLICT.value());
+    DUPLICATE_PLAYLIST_TITLE("이미 존재하는 제목입니다.", HttpStatus.CONFLICT.value()),
+    MAX_RECOMMENDATION_ATTEMPTS_EXCEED("일시적으로 추천 서비스를 이용할 수 없습니다. 잠시 후 다시 시도해주세요", HttpStatus.CONFLICT.value())
+    ;
 
     private final String message;
     private final int status;

--- a/src/main/java/com/my/firstbeat/web/service/RecommendationService.java
+++ b/src/main/java/com/my/firstbeat/web/service/RecommendationService.java
@@ -1,7 +1,9 @@
 package com.my.firstbeat.web.service;
 
+import com.github.benmanes.caffeine.cache.Cache;
 import com.my.firstbeat.client.spotify.SpotifyClient;
 import com.my.firstbeat.client.spotify.dto.response.RecommendationResponse;
+import com.my.firstbeat.client.spotify.ex.SpotifyApiException;
 import com.my.firstbeat.web.controller.track.dto.response.TrackRecommendationResponse;
 import com.my.firstbeat.web.domain.genre.Genre;
 import com.my.firstbeat.web.domain.genre.GenreRepository;
@@ -14,13 +16,17 @@ import com.my.firstbeat.web.ex.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
+
 
 @Service
 @RequiredArgsConstructor
@@ -35,58 +41,125 @@ public class RecommendationService {
     private final PlaylistRepository playlistRepository;
     private final TrackRepository trackRepository;
 
-    private final Map<Long, Queue<TrackRecommendationResponse>> userRecommendationsCache = new ConcurrentHashMap<>();
+    private final Cache<Long, Queue<TrackRecommendationResponse>> recommendationsCache;
     private final Map<Long, ReentrantLock> userLocks = new ConcurrentHashMap<>(); //유저 별 락
     private static final int REFRESH_THRESHOLD = 5; // 5개 남으면 새로 다시 요청
     private static final int RECOMMENDATIONS_SIZE = 20; //한 번에 받아오는 추천 트랙 수
     private static final int MAX_ATTEMPTS = 20; //추천한 곡이 이미 유저의 플레이리스트에 있는 경우 다시 추천 큐에서 꺼내올 수 있는 최대 횟수
-
     private static final int SEED_MAX = 5;
+
+
 
     public TrackRecommendationResponse getRecommendations(Long userId) {
         User user = userService.findByIdOrFail(userId);
+        Queue<TrackRecommendationResponse> recommendations =
+                recommendationsCache.get(userId, key -> new ConcurrentLinkedQueue<>());
 
-        //유저 별 락 획득 (없으면 생성)
-        ReentrantLock userLock = userLocks.computeIfAbsent(user.getId(), k -> new ReentrantLock());
-        Queue<TrackRecommendationResponse> userRecommendations = userRecommendationsCache.computeIfAbsent(user.getId(), k -> new ConcurrentLinkedQueue<>());
+        //락 획득 전 반환할게 있다면 빠른 반환 시도
+        TrackRecommendationResponse quickTry = recommendations.poll();
+        if(quickTry != null && !trackRepository.existsInUserPlaylist(user, quickTry.getSpotifyTrackId())){
+            return quickTry;
+        }
 
-        for(int attempts = 1; attempts <= MAX_ATTEMPTS; attempts++){
+        // 빠르게 반환할 추천 트랙이 없고, 빠르게 반환될 수 있는 트랙이 사용자의 플레이리스트에 있다면
+        // 락을 획득해서 반환 시작
+        ReentrantLock userLock = userLocks.computeIfAbsent(userId, key -> new ReentrantLock());
+
+        for(int attempts = 1; attempts <= MAX_ATTEMPTS; attempts++) {
             userLock.lock();
             try {
-                if(userRecommendations.size() <= REFRESH_THRESHOLD) {
+                if(needsRefresh(recommendations)) {
                     refreshRecommendations(user);
                 }
             } finally {
                 userLock.unlock();
             }
-
-            TrackRecommendationResponse recommendation = userRecommendations.poll();
+            TrackRecommendationResponse recommendation = recommendations.poll();
             if(recommendation == null) {
                 throw new BusinessException(ErrorCode.FAIL_TO_GET_RECOMMENDATION);
             }
-
             if(!trackRepository.existsInUserPlaylist(user, recommendation.getSpotifyTrackId())) {
                 return recommendation;
             }
             log.debug("유저: {}의 플레이리스트에 추천 트랙: {} 존재. 추천 재시도: {}", user.getId(), recommendation.getSpotifyTrackId(), attempts);
         }
-        throw new BusinessException(ErrorCode.NO_NEW_RECOMMENDATIONS_AVAILABLE);
+
+        throw new BusinessException(ErrorCode.MAX_RECOMMENDATION_ATTEMPTS_EXCEED);
     }
 
-    private void refreshRecommendations(User user){
-        String seedGenres = getSeedGenres(user);
-        String seedTracks = getSeedTracks(user);
+    private void refreshRecommendations(User user) {
+        try {
+            String seedGenres = getSeedGenres(user);
+            String seedTracks = getSeedTracks(user);
 
-        RecommendationResponse recommendations = spotifyClient.getRecommendations(seedTracks, seedGenres, RECOMMENDATIONS_SIZE);
+            RecommendationResponse spotifyRecommendations =
+                    spotifyClient.getRecommendations(seedTracks, seedGenres, RECOMMENDATIONS_SIZE);
 
-        Queue<TrackRecommendationResponse> userRecommendations = userRecommendationsCache.computeIfAbsent(
-                user.getId(),k -> new ConcurrentLinkedQueue<>());
+            Queue<TrackRecommendationResponse> recommendations = recommendationsCache.get(user.getId(), key -> new ConcurrentLinkedQueue<>());
+            spotifyRecommendations.getTracks()
+                    .stream()
+                    .map(TrackRecommendationResponse::new)
+                    .forEach(recommendations::offer);
 
-        recommendations.getTracks()
+        } catch (SpotifyApiException e){
+            log.error("Spotify API 호출 실패 - 유저 ID: {}, 원인: {}", user.getId(), e.getMessage(), e);
+            throw e;
+        }
+        catch (Exception e) {
+            log.error("예상치 못한 추천 트랙 갱신 실패 - 유저 ID: {}, 원인: {}", user.getId(), e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    //백그라운드 캐시 갱신
+    @Scheduled(fixedRate = 10, timeUnit = TimeUnit.MINUTES)
+    public void backgroundRefresh(){
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        var refreshEntries = recommendationsCache.asMap()
+                .entrySet()
                 .stream()
-                .map(TrackRecommendationResponse::new)
-                .forEach(userRecommendations::offer);
+                .filter(entry -> needsRefresh(entry.getValue()))
+                .toList();
+        log.info("추천 트랙 갱신 백그라운드 리프레시 시작 - 대상 유저 수: {}", refreshEntries.size());
+
+        refreshEntries
+                .forEach(entry -> {
+                    Long userId = entry.getKey();
+                    ReentrantLock userLock = userLocks.computeIfAbsent(userId, key -> new ReentrantLock());
+                    boolean locked = false;
+
+                    try{
+                        locked = userLock.tryLock(1000, TimeUnit.MILLISECONDS);
+                        if(locked){
+                            User user = userService.findByIdOrFail(userId);
+                            refreshRecommendations(user);
+                            successCount.incrementAndGet();
+                        }
+                    } catch (Exception e){
+                        failCount.incrementAndGet();
+                        log.error("백그라운드 추천 트랙 갱신 작업 실패 - 유저 ID: {}, 원인: {}", userId, e.getMessage(), e);
+                    }finally {
+                        if(locked){
+                            userLock.unlock();
+                        }
+                    }
+                });
+
+        log.info("추천 트랙 갱신 백그라운드 리프레시 완료 - 성공: {}, 실패: {}", successCount.get(), failCount.get());
     }
+
+    //userLock 클린업
+    @Scheduled(fixedRate = 1, timeUnit = TimeUnit.HOURS)
+    private void cleanupUserLocks(){
+        userLocks.keySet().removeIf(userId -> !recommendationsCache.asMap().containsKey(userId));
+    }
+
+    private boolean needsRefresh(Queue<TrackRecommendationResponse> recommendations) {
+        return recommendations.size() <= REFRESH_THRESHOLD;
+    }
+
 
     private String getSeedGenres(User user){
         String seedGenres = genreRepository.findTop5GenresByUser(user, PageRequest.of(0, SEED_MAX))
@@ -98,6 +171,7 @@ public class RecommendationService {
         }
         return seedGenres;
     }
+
 
     private String getSeedTracks(User user){
         List<Track> trackList = new ArrayList<>(playlistRepository.findAllTrackByUser(user));

--- a/src/main/java/com/my/firstbeat/web/service/RecommendationService.java
+++ b/src/main/java/com/my/firstbeat/web/service/RecommendationService.java
@@ -1,0 +1,108 @@
+package com.my.firstbeat.web.service;
+
+import com.my.firstbeat.client.spotify.SpotifyClient;
+import com.my.firstbeat.client.spotify.dto.response.RecommendationResponse;
+import com.my.firstbeat.web.controller.track.dto.response.TrackRecommendationResponse;
+import com.my.firstbeat.web.domain.genre.Genre;
+import com.my.firstbeat.web.domain.genre.GenreRepository;
+import com.my.firstbeat.web.domain.playlist.PlaylistRepository;
+import com.my.firstbeat.web.domain.track.Track;
+import com.my.firstbeat.web.domain.track.TrackRepository;
+import com.my.firstbeat.web.domain.user.User;
+import com.my.firstbeat.web.ex.BusinessException;
+import com.my.firstbeat.web.ex.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+//락 적용
+public class RecommendationService {
+
+    private final SpotifyClient spotifyClient;
+    private final UserService userService;
+    private final GenreRepository genreRepository;
+    private final PlaylistRepository playlistRepository;
+    private final TrackRepository trackRepository;
+
+    private final Map<Long, Queue<TrackRecommendationResponse>> userRecommendationsCache = new ConcurrentHashMap<>();
+    private final Map<Long, ReentrantLock> userLocks = new ConcurrentHashMap<>(); //유저 별 락
+    private static final int REFRESH_THRESHOLD = 5; // 5개 남으면 새로 다시 요청
+    private static final int RECOMMENDATIONS_SIZE = 20; //한 번에 받아오는 추천 트랙 수
+    private static final int MAX_ATTEMPTS = 20; //추천한 곡이 이미 유저의 플레이리스트에 있는 경우 다시 추천 큐에서 꺼내올 수 있는 최대 횟수
+
+    public TrackRecommendationResponse getRecommendations(Long userId) {
+        User user = userService.findByIdOrFail(userId);
+
+        //유저 별 락 획득 (없으면 생성)
+        ReentrantLock userLock = userLocks.computeIfAbsent(user.getId(), k -> new ReentrantLock());
+        Queue<TrackRecommendationResponse> userRecommendations = userRecommendationsCache.computeIfAbsent(user.getId(), k -> new ConcurrentLinkedQueue<>());
+
+        for(int attempts = 1; attempts <= MAX_ATTEMPTS; attempts++){
+            userLock.lock();
+            try {
+                if(userRecommendations.size() <= REFRESH_THRESHOLD) {
+                    refreshRecommendations(user);
+                }
+            } finally {
+                userLock.unlock();
+            }
+
+            TrackRecommendationResponse recommendation = userRecommendations.poll();
+            if(recommendation == null) {
+                throw new BusinessException(ErrorCode.FAIL_TO_GET_RECOMMENDATION);
+            }
+
+            if(!trackRepository.existsInUserPlaylist(user, recommendation.getSpotifyTrackId())) {
+                return recommendation;
+            }
+            log.debug("유저: {}의 플레이리스트에 추천 트랙: {} 존재. 추천 재시도: {}", user.getId(), recommendation.getSpotifyTrackId(), attempts);
+        }
+        throw new BusinessException(ErrorCode.NO_NEW_RECOMMENDATIONS_AVAILABLE);
+    }
+
+    private void refreshRecommendations(User user){
+        String seedGenres = getSeedGenres(user);
+        String seedTracks = getSeedTracks(user);
+
+        RecommendationResponse recommendations = spotifyClient.getRecommendations(seedTracks, seedGenres, RECOMMENDATIONS_SIZE);
+
+        Queue<TrackRecommendationResponse> userRecommendations = userRecommendationsCache.computeIfAbsent(
+                user.getId(),k -> new ConcurrentLinkedQueue<>());
+
+        recommendations.getTracks()
+                .stream()
+                .map(TrackRecommendationResponse::new)
+                .forEach(userRecommendations::offer);
+    }
+
+    private String getSeedGenres(User user){
+        String seedGenres = genreRepository.findTop5GenresByUser(user, PageRequest.of(0, 5))
+                .stream()
+                .map(Genre::getName)
+                .collect(Collectors.joining(","));
+        if(seedGenres.isEmpty()){
+            throw new BusinessException(ErrorCode.GENRES_NOT_FOUND);
+        }
+        return seedGenres;
+    }
+
+    private String getSeedTracks(User user){
+        List<Track> trackList = new ArrayList<>(playlistRepository.findAllTrackByUser(user));
+        Collections.shuffle(trackList);
+        return trackList.stream()
+                .limit(5)
+                .map(Track::getSpotifyTrackId)
+                .collect(Collectors.joining(","));
+    }
+}

--- a/src/main/java/com/my/firstbeat/web/service/RecommendationService.java
+++ b/src/main/java/com/my/firstbeat/web/service/RecommendationService.java
@@ -174,8 +174,7 @@ public class RecommendationService {
 
 
     private String getSeedTracks(User user){
-        List<Track> trackList = new ArrayList<>(playlistRepository.findAllTrackByUser(user));
-        Collections.shuffle(trackList);
+        List<Track> trackList = playlistRepository.findAllTrackByUser(user, PageRequest.of(0, SEED_MAX));
         return trackList.stream()
                 .limit(SEED_MAX)
                 .map(Track::getSpotifyTrackId)

--- a/src/main/java/com/my/firstbeat/web/service/RecommendationService.java
+++ b/src/main/java/com/my/firstbeat/web/service/RecommendationService.java
@@ -41,6 +41,8 @@ public class RecommendationService {
     private static final int RECOMMENDATIONS_SIZE = 20; //한 번에 받아오는 추천 트랙 수
     private static final int MAX_ATTEMPTS = 20; //추천한 곡이 이미 유저의 플레이리스트에 있는 경우 다시 추천 큐에서 꺼내올 수 있는 최대 횟수
 
+    private static final int SEED_MAX = 5;
+
     public TrackRecommendationResponse getRecommendations(Long userId) {
         User user = userService.findByIdOrFail(userId);
 
@@ -87,7 +89,7 @@ public class RecommendationService {
     }
 
     private String getSeedGenres(User user){
-        String seedGenres = genreRepository.findTop5GenresByUser(user, PageRequest.of(0, 5))
+        String seedGenres = genreRepository.findTop5GenresByUser(user, PageRequest.of(0, SEED_MAX))
                 .stream()
                 .map(Genre::getName)
                 .collect(Collectors.joining(","));
@@ -101,7 +103,7 @@ public class RecommendationService {
         List<Track> trackList = new ArrayList<>(playlistRepository.findAllTrackByUser(user));
         Collections.shuffle(trackList);
         return trackList.stream()
-                .limit(5)
+                .limit(SEED_MAX)
                 .map(Track::getSpotifyTrackId)
                 .collect(Collectors.joining(","));
     }

--- a/src/main/java/com/my/firstbeat/web/service/RecommendationServiceWithoutLock.java
+++ b/src/main/java/com/my/firstbeat/web/service/RecommendationServiceWithoutLock.java
@@ -104,8 +104,7 @@ public class RecommendationServiceWithoutLock {
     }
 
     private String getSeedTracks(User user){
-        List<Track> trackList = new ArrayList<>(playlistRepository.findAllTrackByUser(user));
-        Collections.shuffle(trackList);
+        List<Track> trackList = playlistRepository.findAllTrackByUser(user, PageRequest.of(0, SEED_MAX));
         return trackList.stream()
                 .limit(SEED_MAX)
                 .map(Track::getSpotifyTrackId)

--- a/src/main/java/com/my/firstbeat/web/service/RecommendationServiceWithoutLock.java
+++ b/src/main/java/com/my/firstbeat/web/service/RecommendationServiceWithoutLock.java
@@ -39,6 +39,8 @@ public class RecommendationServiceWithoutLock {
     private static final int RECOMMENDATIONS_SIZE = 20; //한 번에 받아오는 추천 트랙 수
     private static final int MAX_ATTEMPTS = 20; //추천한 곡이 이미 유저의 플레이리스트에 있는 경우 다시 추천 큐에서 꺼내올 수 있는 최대 횟수
 
+    private static final int SEED_MAX = 5;
+
     public TrackRecommendationResponse getRecommendations(Long userId) {
         //사용자 검증
         User user = userService.findByIdOrFail(userId);
@@ -91,7 +93,7 @@ public class RecommendationServiceWithoutLock {
 
     private String getSeedGenres(User user){
 
-        String seedGenres = genreRepository.findTop5GenresByUser(user, PageRequest.of(0, 5))
+        String seedGenres = genreRepository.findTop5GenresByUser(user, PageRequest.of(0, SEED_MAX))
                 .stream()
                 .map(Genre::getName)
                 .collect(Collectors.joining(","));
@@ -105,7 +107,7 @@ public class RecommendationServiceWithoutLock {
         List<Track> trackList = new ArrayList<>(playlistRepository.findAllTrackByUser(user));
         Collections.shuffle(trackList);
         return trackList.stream()
-                .limit(5)
+                .limit(SEED_MAX)
                 .map(Track::getSpotifyTrackId)
                 .collect(Collectors.joining(","));
     }

--- a/src/main/java/com/my/firstbeat/web/service/RecommendationServiceWithoutLock.java
+++ b/src/main/java/com/my/firstbeat/web/service/RecommendationServiceWithoutLock.java
@@ -1,0 +1,112 @@
+package com.my.firstbeat.web.service;
+
+import com.my.firstbeat.client.spotify.SpotifyClient;
+import com.my.firstbeat.client.spotify.dto.response.RecommendationResponse;
+import com.my.firstbeat.web.controller.track.dto.response.TrackRecommendationResponse;
+import com.my.firstbeat.web.domain.genre.Genre;
+import com.my.firstbeat.web.domain.genre.GenreRepository;
+import com.my.firstbeat.web.domain.playlist.PlaylistRepository;
+import com.my.firstbeat.web.domain.track.Track;
+import com.my.firstbeat.web.domain.track.TrackRepository;
+import com.my.firstbeat.web.domain.user.User;
+import com.my.firstbeat.web.ex.BusinessException;
+import com.my.firstbeat.web.ex.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class RecommendationServiceWithoutLock {
+
+    private final SpotifyClient spotifyClient;
+    private final UserService userService;
+    private final GenreRepository genreRepository;
+    private final PlaylistRepository playlistRepository;
+    private final TrackRepository trackRepository;
+
+    private final Map<Long, Queue<TrackRecommendationResponse>> userRecommendationsCache = new ConcurrentHashMap<>();
+    private static final int REFRESH_THRESHOLD = 5; // 5개 남으면 새로 다시 요청
+    private static final int RECOMMENDATIONS_SIZE = 20; //한 번에 받아오는 추천 트랙 수
+    private static final int MAX_ATTEMPTS = 20; //추천한 곡이 이미 유저의 플레이리스트에 있는 경우 다시 추천 큐에서 꺼내올 수 있는 최대 횟수
+
+    public TrackRecommendationResponse getRecommendations(Long userId) {
+        //사용자 검증
+        User user = userService.findByIdOrFail(userId);
+
+        //해당 유저의 추천 트랙 가져오기
+        Queue<TrackRecommendationResponse> userRecommendations = userRecommendationsCache.computeIfAbsent(user.getId(), k -> new ConcurrentLinkedQueue<>());
+
+        for(int attempts = 1; attempts <= MAX_ATTEMPTS; attempts++){
+            //비어있거나 5개 이하면 다시 spotifyClient 로 요청
+            //TODO 이거 스레드 동시성 처리하면 트레이드 오프가 있는지
+            if(userRecommendations.size() <= REFRESH_THRESHOLD) {
+                refreshRecommendations(user);
+            }
+
+            TrackRecommendationResponse trackRecommendationResponse = userRecommendations.poll();
+            if(trackRecommendationResponse == null){
+                throw new BusinessException(ErrorCode.FAIL_TO_GET_RECOMMENDATION);
+            }
+
+            //추천하려는 장르가 이미 유저의 플레이리스트에 있는 곡이라면 패스
+            if(!trackRepository.existsInUserPlaylist(user, trackRecommendationResponse.getSpotifyTrackId())){
+                return trackRecommendationResponse;
+            }
+
+            log.debug("유저: {}의 플레이리스트에 추천 트랙: {} 존재. 추천 재시도: {}",
+                    user.getId(), trackRecommendationResponse.getSpotifyTrackId(), attempts);
+        }
+        throw new BusinessException(ErrorCode.NO_NEW_RECOMMENDATIONS_AVAILABLE);
+    }
+
+    private void refreshRecommendations(User user){
+        //사용자 선호 장르 조회 (최대 5개)
+        String seedGenres = getSeedGenres(user);
+
+        //사용자의 모든 플레이리스트에 있는 트랙 총 5개 랜덤 조회
+        String seedTracks = getSeedTracks(user);
+
+        //해당 장르와 해당 트랙 전달
+        RecommendationResponse recommendations = spotifyClient.getRecommendations(seedTracks, seedGenres, RECOMMENDATIONS_SIZE);
+
+        //추천 트랙 리스트 추가
+        Queue<TrackRecommendationResponse> userRecommendations = userRecommendationsCache.computeIfAbsent(
+                user.getId(),k -> new ConcurrentLinkedQueue<>());
+
+        recommendations.getTracks()
+                .stream()
+                .map(TrackRecommendationResponse::new)
+                .forEach(userRecommendations::offer);
+    }
+
+    private String getSeedGenres(User user){
+
+        String seedGenres = genreRepository.findTop5GenresByUser(user, PageRequest.of(0, 5))
+                .stream()
+                .map(Genre::getName)
+                .collect(Collectors.joining(","));
+        if(seedGenres.isEmpty()){
+            throw new BusinessException(ErrorCode.GENRES_NOT_FOUND);
+        }
+        return seedGenres;
+    }
+
+    private String getSeedTracks(User user){
+        List<Track> trackList = new ArrayList<>(playlistRepository.findAllTrackByUser(user));
+        Collections.shuffle(trackList);
+        return trackList.stream()
+                .limit(5)
+                .map(Track::getSpotifyTrackId)
+                .collect(Collectors.joining(","));
+    }
+}

--- a/src/main/java/com/my/firstbeat/web/service/TrackService.java
+++ b/src/main/java/com/my/firstbeat/web/service/TrackService.java
@@ -33,16 +33,6 @@ import java.util.stream.Collectors;
 public class TrackService {
 
     private final SpotifyClient spotifyClient;
-    private final UserService userService;
-    private final GenreRepository genreRepository;
-    private final PlaylistRepository playlistRepository;
-    private final TrackRepository trackRepository;
-
-    private final Map<Long, Queue<TrackRecommendationResponse>> userRecommendationsCache = new ConcurrentHashMap<>();
-    private static final int REFRESH_THRESHOLD = 5; // 5개 남으면 새로 다시 요청
-    private static final int RECOMMENDATIONS_SIZE = 20; //한 번에 받아오는 추천 트랙 수
-    private static final int MAX_ATTEMPTS = 20; //추천한 곡이 이미 유저의 플레이리스트에 있는 경우 다시 추천 큐에서 꺼내올 수 있는 최대 횟수
-
 
     public TrackSearchResponse searchTrackList(String genre){
         try {
@@ -59,74 +49,5 @@ public class TrackService {
         }
     }
 
-    public TrackRecommendationResponse getRecommendations(Long userId) {
-        //사용자 검증
-        User user = userService.findByIdOrFail(userId);
 
-        //해당 유저의 추천 트랙 가져오기
-        Queue<TrackRecommendationResponse> userRecommendations = userRecommendationsCache.computeIfAbsent(user.getId(), k -> new ConcurrentLinkedQueue<>());
-
-        for(int attempts = 1; attempts <= MAX_ATTEMPTS; attempts++){
-            //비어있거나 5개 이하면 다시 spotifyClient 로 요청
-            //TODO 이거 스레드 동시성 처리하면 트레이드 오프가 있는지
-            if(userRecommendations.size() <= REFRESH_THRESHOLD) {
-                refreshRecommendations(user);
-            }
-
-            TrackRecommendationResponse trackRecommendationResponse = userRecommendations.poll();
-            if(trackRecommendationResponse == null){
-                throw new BusinessException(ErrorCode.FAIL_TO_GET_RECOMMENDATION);
-            }
-
-            //추천하려는 장르가 이미 유저의 플레이리스트에 있는 곡이라면 패스
-            if(!trackRepository.existsInUserPlaylist(user, trackRecommendationResponse.getSpotifyTrackId())){
-                return trackRecommendationResponse;
-            }
-
-            log.debug("유저: {}의 플레이리스트에 추천 트랙: {} 존재. 추천 재시도: {}",
-                    user.getId(), trackRecommendationResponse.getSpotifyTrackId(), attempts);
-        }
-        throw new BusinessException(ErrorCode.NO_NEW_RECOMMENDATIONS_AVAILABLE);
-    }
-
-    private void refreshRecommendations(User user){
-        //사용자 선호 장르 조회 (최대 5개)
-        String seedGenres = getSeedGenres(user);
-
-        //사용자의 모든 플레이리스트에 있는 트랙 총 5개 랜덤 조회
-        String seedTracks = getSeedTracks(user);
-
-        //해당 장르와 해당 트랙 전달
-        RecommendationResponse recommendations = spotifyClient.getRecommendations(seedTracks, seedGenres, RECOMMENDATIONS_SIZE);
-
-        //추천 트랙 리스트 추가
-        Queue<TrackRecommendationResponse> userRecommendations = userRecommendationsCache.computeIfAbsent(
-                user.getId(),k -> new ConcurrentLinkedQueue<>());
-
-        recommendations.getTracks()
-                .stream()
-                .map(TrackRecommendationResponse::new)
-                .forEach(userRecommendations::offer);
-    }
-
-    private String getSeedGenres(User user){
-
-        String seedGenres = genreRepository.findTop5GenresByUser(user, PageRequest.of(0, 5))
-                .stream()
-                .map(Genre::getName)
-                .collect(Collectors.joining(","));
-        if(seedGenres.isEmpty()){
-            throw new BusinessException(ErrorCode.GENRES_NOT_FOUND);
-        }
-        return seedGenres;
-    }
-
-    private String getSeedTracks(User user){
-        List<Track> trackList = new ArrayList<>(playlistRepository.findAllTrackByUser(user));
-        Collections.shuffle(trackList);
-        return trackList.stream()
-                .limit(5)
-                .map(Track::getSpotifyTrackId)
-                .collect(Collectors.joining(","));
-    }
 }

--- a/src/main/java/com/my/firstbeat/web/service/TrackService.java
+++ b/src/main/java/com/my/firstbeat/web/service/TrackService.java
@@ -1,12 +1,31 @@
 package com.my.firstbeat.web.service;
 
 import com.my.firstbeat.client.spotify.SpotifyClient;
+import com.my.firstbeat.client.spotify.dto.response.RecommendationResponse;
 import com.my.firstbeat.client.spotify.dto.response.TrackSearchResponse;
 import com.my.firstbeat.client.spotify.ex.SpotifyApiException;
+import com.my.firstbeat.web.controller.track.dto.response.TrackRecommendationResponse;
+import com.my.firstbeat.web.domain.genre.Genre;
+import com.my.firstbeat.web.domain.playlist.PlaylistRepository;
+import com.my.firstbeat.web.domain.playlistTrack.PlaylistTrackRepository;
+import com.my.firstbeat.web.domain.track.Track;
+import com.my.firstbeat.web.domain.track.TrackRepository;
+import com.my.firstbeat.web.domain.user.User;
+import com.my.firstbeat.web.domain.userGenre.UserGenreRepository;
+import com.my.firstbeat.web.ex.BusinessException;
+import com.my.firstbeat.web.ex.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -15,6 +34,15 @@ import org.springframework.transaction.annotation.Transactional;
 public class TrackService {
 
     private final SpotifyClient spotifyClient;
+    private final UserService userService;
+    private final UserGenreRepository userGenreRepository;
+    private final PlaylistRepository playlistRepository;
+    private final TrackRepository trackRepository;
+
+    private final Map<Long, Queue<TrackRecommendationResponse>> userRecommendationsCache = new ConcurrentHashMap<>();
+    private static final int REFRESH_THRESHOLD = 5; // 5개 남으면 새로 다시 요청
+    private static final int RECOMMENDATIONS_SIZE = 20; //한 번에 받아오는 추천 트랙 수
+    private static final int MAX_ATTEMPTS = 20; //추천한 곡이 이미 유저의 플레이리스트에 있는 경우 다시 추천 큐에서 꺼내올 수 있는 최대 횟수
 
 
     public TrackSearchResponse searchTrackList(String genre){
@@ -30,5 +58,72 @@ public class TrackService {
             log.error("트랙 검색 중 오류 발생 - 장르: {}", genre);
             throw e;
         }
+    }
+
+    public TrackRecommendationResponse getRecommendations(Long userId) {
+        //사용자 검증
+        User user = userService.findByIdOrFail(userId);
+
+        //해당 유저의 추천 트랙 가져오기
+        Queue<TrackRecommendationResponse> userRecommendations = userRecommendationsCache.computeIfAbsent(user.getId(), k -> new ConcurrentLinkedQueue<>());
+
+        for(int attempts = 1; attempts <= MAX_ATTEMPTS; attempts++){
+            //비어있거나 5개 이하면 다시 spotifyClient 로 요청
+            //TODO 이거 스레드 동시성 처리하면 트레이드 오프가 있는지 테스트
+            if(userRecommendations.size() <= REFRESH_THRESHOLD){
+                refreshRecommendations(user);
+            }
+
+            TrackRecommendationResponse trackRecommendationResponse = userRecommendations.poll();
+            if(trackRecommendationResponse == null){
+                throw new BusinessException(ErrorCode.FAIL_TO_GET_RECOMMENDATION);
+            }
+
+            //추천하려는 장르가 이미 유저의 플레이리스트에 있는 곡이라면 패스
+            if(!trackRepository.existsInUserPlaylist(user, trackRecommendationResponse.getSpotifyTrackId())){
+                return trackRecommendationResponse;
+            }
+
+            log.debug("유저: {}의 플레이리스트에 추천 트랙: {} 존재. 추천 재시도: {}",
+                    user.getId(), trackRecommendationResponse.getSpotifyTrackId(), attempts);
+        }
+        throw new BusinessException(ErrorCode.NO_NEW_RECOMMENDATIONS_AVAILABLE);
+    }
+
+    private void refreshRecommendations(User user){
+        //사용자 선호 장르 조회 (최대 5개)
+        String seedGenres = getSeedGenres(user);
+
+        //사용자의 모든 플레이리스트에 있는 트랙 총 5개 랜덤 조회
+        String seedTracks = getSeedTracks(user);
+
+        //해당 장르와 해당 트랙 전달
+        RecommendationResponse recommendations = spotifyClient.getRecommendations(seedTracks, seedGenres, RECOMMENDATIONS_SIZE);
+
+        //추천 트랙 리스트 추가
+        Queue<TrackRecommendationResponse> userRecommendations = userRecommendationsCache.get(user.getId());
+        recommendations.getTracks()
+                .stream()
+                .map(TrackRecommendationResponse::new);
+    }
+
+    private String getSeedGenres(User user){
+        String seedGenres = userGenreRepository.findTop5GenresByUser(user)
+                .stream()
+                .map(Genre::getName)
+                .collect(Collectors.joining(","));
+        if(seedGenres.isEmpty()){
+            throw new BusinessException(ErrorCode.GENRES_NOT_FOUND);
+        }
+        return seedGenres;
+    }
+
+    private String getSeedTracks(User user){
+        List<Track> trackList = playlistRepository.findAllTrackByUser(user);
+        Collections.shuffle(trackList);
+        return trackList.stream()
+                .limit(5)
+                .map(Track::getSpotifyTrackId)
+                .collect(Collectors.joining(","));
     }
 }

--- a/src/main/java/com/my/firstbeat/web/service/UserService.java
+++ b/src/main/java/com/my/firstbeat/web/service/UserService.java
@@ -1,5 +1,9 @@
 package com.my.firstbeat.web.service;
 
+import com.my.firstbeat.web.domain.user.User;
+import com.my.firstbeat.web.domain.user.UserRepository;
+import com.my.firstbeat.web.ex.BusinessException;
+import com.my.firstbeat.web.ex.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -10,4 +14,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 @Slf4j
 public class UserService {
+
+    private final UserRepository userRepository;
+
+    public User findByIdOrFail(Long id){
+        return userRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUNT));
+    }
 }

--- a/src/test/java/com/my/firstbeat/web/service/RecommendationServiceTest.java
+++ b/src/test/java/com/my/firstbeat/web/service/RecommendationServiceTest.java
@@ -2,7 +2,6 @@ package com.my.firstbeat.web.service;
 
 import com.my.firstbeat.client.spotify.SpotifyClient;
 import com.my.firstbeat.client.spotify.dto.response.RecommendationResponse;
-import com.my.firstbeat.client.spotify.dto.response.TrackSearchResponse;
 import com.my.firstbeat.web.controller.track.dto.response.TrackRecommendationResponse;
 import com.my.firstbeat.web.domain.genre.Genre;
 import com.my.firstbeat.web.domain.genre.GenreRepository;
@@ -19,6 +18,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.ArrayList;
@@ -81,7 +81,7 @@ class RecommendationServiceTest extends DummyObject {
         given(trackRepository.existsInUserPlaylist(any(), anyString())).willReturn(false);
         given(genreRepository.findTop5GenresByUser(any(), any())).willReturn(
                 List.of(new Genre("pop"), new Genre("k-pop")));
-        given(playlistRepository.findAllTrackByUser(any()))
+        given(playlistRepository.findAllTrackByUser(any(), any(Pageable.class)))
                 .willReturn(List.of(Track.builder().spotifyTrackId("test1").build(),
                         Track.builder().spotifyTrackId("test2").build()));
 

--- a/src/test/java/com/my/firstbeat/web/service/RecommendationServiceUnitTest.java
+++ b/src/test/java/com/my/firstbeat/web/service/RecommendationServiceUnitTest.java
@@ -1,0 +1,54 @@
+package com.my.firstbeat.web.service;
+
+import com.my.firstbeat.client.spotify.SpotifyClient;
+import com.my.firstbeat.web.domain.genre.GenreRepository;
+import com.my.firstbeat.web.domain.playlist.PlaylistRepository;
+import com.my.firstbeat.web.domain.track.TrackRepository;
+import com.my.firstbeat.web.domain.user.User;
+import com.my.firstbeat.web.dummy.DummyObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+class RecommendationServiceUnitTest extends DummyObject {
+
+    @InjectMocks
+    private RecommendationService recommendationService;
+
+    @Mock
+    private SpotifyClient spotifyClient;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private GenreRepository genreRepository;
+
+    @Mock
+    private PlaylistRepository playlistRepository;
+
+    @Mock
+    private TrackRepository trackRepository;
+
+    private User testUser;
+
+    private Long userId;
+
+    @BeforeEach
+    void setUp(){
+        testUser = mockUser();
+        userId = 1L;
+    }
+
+//    @Test
+//    @DisplayName("추천 트랙 조회: 캐시에 충분한 추천곡이 있고, 플레이리스트에 없는 경우 즉시 반환")
+//
+
+}

--- a/src/test/java/com/my/firstbeat/web/service/RecommendationServiceUnitTest.java
+++ b/src/test/java/com/my/firstbeat/web/service/RecommendationServiceUnitTest.java
@@ -1,8 +1,13 @@
 package com.my.firstbeat.web.service;
 
+import com.github.benmanes.caffeine.cache.Cache;
 import com.my.firstbeat.client.spotify.SpotifyClient;
+import com.my.firstbeat.client.spotify.dto.response.TrackSearchResponse;
+import com.my.firstbeat.web.controller.track.dto.response.TrackRecommendationResponse;
+import com.my.firstbeat.web.domain.genre.Genre;
 import com.my.firstbeat.web.domain.genre.GenreRepository;
 import com.my.firstbeat.web.domain.playlist.PlaylistRepository;
+import com.my.firstbeat.web.domain.track.Track;
 import com.my.firstbeat.web.domain.track.TrackRepository;
 import com.my.firstbeat.web.domain.user.User;
 import com.my.firstbeat.web.dummy.DummyObject;
@@ -13,7 +18,20 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import static com.my.firstbeat.client.spotify.dto.response.TrackSearchResponse.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 @ActiveProfiles("test")
@@ -37,6 +55,9 @@ class RecommendationServiceUnitTest extends DummyObject {
     @Mock
     private TrackRepository trackRepository;
 
+    @Mock
+    private Cache<Long, Queue<TrackRecommendationResponse>> recommendationCache;
+
     private User testUser;
 
     private Long userId;
@@ -47,8 +68,32 @@ class RecommendationServiceUnitTest extends DummyObject {
         userId = 1L;
     }
 
-//    @Test
-//    @DisplayName("추천 트랙 조회: 캐시에 충분한 추천곡이 있고, 플레이리스트에 없는 경우 즉시 반환")
-//
+    @Test
+    @DisplayName("추천 트랙 조회: 캐시에 충분한 추천곡이 있고, 플레이리스트에 없는 경우 즉시 반환")
+    void getRecommendations_with_sufficientCache_and_not_in_playlist(){
+
+        TrackRecommendationResponse response = new TrackRecommendationResponse(TrackResponse.builder()
+                .trackName("트랙 이름")
+                .id("spotifyTrackId")
+                .artists(new TrackResponse.ArtistResponse("아티스트 이름"))
+                .isPlayable(true)
+                .previewUrl("프리뷰 url")
+                .build());
+
+        Queue<TrackRecommendationResponse> recommendations = new ConcurrentLinkedQueue<>();
+        recommendations.offer(response);
+
+        given(userService.findByIdOrFail(userId)).willReturn(testUser);
+        given(recommendationCache.get(eq(userId), any())).willReturn(recommendations);
+        given(trackRepository.existsInUserPlaylist(testUser, response.getSpotifyTrackId())).willReturn(false);
+
+        //when
+        TrackRecommendationResponse result = recommendationService.getRecommendations(userId);
+
+        assertThat(result).isEqualTo(response);
+        verify(spotifyClient, never()).getRecommendations(anyString(), anyString(), anyInt());
+    }
+
+
 
 }

--- a/src/test/java/com/my/firstbeat/web/service/RecommendationServiceWithoutLockTest.java
+++ b/src/test/java/com/my/firstbeat/web/service/RecommendationServiceWithoutLockTest.java
@@ -19,6 +19,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.ArrayList;
@@ -81,7 +82,7 @@ class RecommendationServiceWithoutLockTest extends DummyObject {
         given(trackRepository.existsInUserPlaylist(any(), anyString())).willReturn(false);
         given(genreRepository.findTop5GenresByUser(any(), any())).willReturn(
                 List.of(new Genre("pop"), new Genre("k-pop")));
-        given(playlistRepository.findAllTrackByUser(any()))
+        given(playlistRepository.findAllTrackByUser(any(), any(Pageable.class)))
                 .willReturn(List.of(Track.builder().spotifyTrackId("test1").build(),
                         Track.builder().spotifyTrackId("test2").build()));
 

--- a/src/test/java/com/my/firstbeat/web/service/RecommendationServiceWithoutLockTest.java
+++ b/src/test/java/com/my/firstbeat/web/service/RecommendationServiceWithoutLockTest.java
@@ -1,0 +1,167 @@
+package com.my.firstbeat.web.service;
+
+import com.my.firstbeat.client.spotify.SpotifyClient;
+import com.my.firstbeat.client.spotify.dto.response.RecommendationResponse;
+import com.my.firstbeat.client.spotify.dto.response.TrackSearchResponse;
+import com.my.firstbeat.web.controller.track.dto.response.TrackRecommendationResponse;
+import com.my.firstbeat.web.domain.genre.Genre;
+import com.my.firstbeat.web.domain.genre.GenreRepository;
+import com.my.firstbeat.web.domain.playlist.PlaylistRepository;
+import com.my.firstbeat.web.domain.track.Track;
+import com.my.firstbeat.web.domain.track.TrackRepository;
+import com.my.firstbeat.web.domain.user.Role;
+import com.my.firstbeat.web.domain.user.User;
+import com.my.firstbeat.web.dummy.DummyObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.my.firstbeat.client.spotify.dto.response.TrackSearchResponse.TrackResponse.builder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class RecommendationServiceWithoutLockTest extends DummyObject {
+    @Autowired
+    private RecommendationServiceWithoutLock recommendationService;
+
+    @MockBean
+    private SpotifyClient spotifyClient;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private TrackRepository trackRepository;
+
+    @MockBean
+    private GenreRepository genreRepository;
+
+    @MockBean
+    private PlaylistRepository playlistRepository;
+
+    private User testUser;
+
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
+
+
+    @Test
+    @DisplayName("여러 스레드가 동시에 캐시 리프레시 시도할 때 중복 리프레시 발생")
+    void getRecommendations_with_concurrent_refresh_requests_should_cause_duplicatedRefresh() throws InterruptedException {
+
+        int concurrentRequests = 50;
+        int expectedMinimumApiCalls = 3;
+
+        ExecutorService executorService = Executors.newFixedThreadPool(concurrentRequests);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch completionLatch = new CountDownLatch(concurrentRequests);
+        AtomicInteger apiCallCount = new AtomicInteger(0); //api 호출 카운트
+
+        testUser = new User(1L, "test@naver.com", Role.USER);
+        given(userService.findByIdOrFail(anyLong())).willReturn(testUser);
+
+        given(trackRepository.existsInUserPlaylist(any(), anyString())).willReturn(false);
+        given(genreRepository.findTop5GenresByUser(any(), any())).willReturn(
+                List.of(new Genre("pop"), new Genre("k-pop")));
+        given(playlistRepository.findAllTrackByUser(any()))
+                .willReturn(List.of(Track.builder().spotifyTrackId("test1").build(),
+                        Track.builder().spotifyTrackId("test2").build()));
+
+
+        given(spotifyClient.getRecommendations(anyString(), anyString(), anyInt()))
+                .willAnswer(invocation -> {
+
+                    log.info("Spotify API 호출: {}", System.currentTimeMillis());
+                    apiCallCount.incrementAndGet();
+
+                    Thread.sleep(100);
+
+                    RecommendationResponse response = new RecommendationResponse();
+
+                    List<TrackSearchResponse.TrackResponse> tracks = IntStream.range(0, 20)
+                            .mapToObj(i -> builder()
+                                    .id("spotifyId: "+i)
+                                    .artists(new TrackSearchResponse.TrackResponse.ArtistResponse("nct wish"))
+                                    .build())
+                            .collect(Collectors.toList());
+                    response.setTracks(tracks);
+                    return response;
+                });
+
+
+        //캐시 초기화를 위해 첫 번째 호출 수행
+        recommendationService.getRecommendations(testUser.getId());
+
+
+        //여러 스레드에서 동시에 요청
+        List<Future<TrackRecommendationResponse>> futures = new ArrayList<>();
+        for(int i = 0;i<concurrentRequests; i++){
+            futures.add(executorService.submit(() ->{
+                startLatch.await();
+                try{
+                    return recommendationService.getRecommendations(testUser.getId());
+                }finally {
+                    completionLatch.countDown();
+                }
+            }));
+
+            if (i % 5 == 0) {
+                Thread.sleep(10);
+            }
+        }
+
+        startLatch.countDown(); // 동시 요청 시작
+        completionLatch.await(10, TimeUnit.SECONDS);
+
+
+        List<TrackRecommendationResponse> results = futures.stream()
+                .map(future -> {
+                    try {
+                        return future.get();
+                    } catch (Exception e) {
+                        fail("Future 실행 중 예외 발생: " + e.getMessage());
+                        return null;
+                    }
+                })
+                .toList();
+
+        int actualApiCalls = apiCallCount.get();
+        log.info("기대한 최소 API 호출 수: {}, 실제 발생한 API 호출 수: {}", expectedMinimumApiCalls, actualApiCalls);
+
+
+        assertAll(
+                () -> assertThat(results).hasSize(concurrentRequests), //모든 요청 성공
+                () -> {
+
+                    //중복 발생했는지
+                    assertThat(actualApiCalls)
+                            .as("api 호출 기대값: %d. 경쟁 상태로 인해 API 중복 호출 발생: %d ", expectedMinimumApiCalls, actualApiCalls)
+                            .isGreaterThan(expectedMinimumApiCalls)
+                            .isLessThan(concurrentRequests);
+                },
+                () -> verify(spotifyClient, atLeast(expectedMinimumApiCalls + 1))
+                        .getRecommendations(anyString(), anyString(), anyInt())
+        );
+
+
+        executorService.shutdown();
+    }
+}

--- a/src/test/java/com/my/firstbeat/web/service/RecommendationServiceWithoutLockUnitTest.java
+++ b/src/test/java/com/my/firstbeat/web/service/RecommendationServiceWithoutLockUnitTest.java
@@ -22,6 +22,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ActiveProfiles;
 import java.util.*;
 import java.util.concurrent.*;
@@ -64,6 +65,7 @@ class RecommendationServiceWithoutLockUnitTest extends DummyObject {
     private User testUser;
     private static final int CONCURRENT_USERS = 10;
     private static final int REQUESTS_PER_USER = 5;
+    private static final int SEED_MAX = 5;
 
     private final Logger log = LoggerFactory.getLogger(this.getClass());
 
@@ -75,7 +77,7 @@ class RecommendationServiceWithoutLockUnitTest extends DummyObject {
         given(trackRepository.existsInUserPlaylist(any(), anyString())).willReturn(false);
         given(genreRepository.findTop5GenresByUser(any(), any())).willReturn(
                 List.of(new Genre("pop"), new Genre("k-pop")));
-        given(playlistRepository.findAllTrackByUser(any()))
+        given(playlistRepository.findAllTrackByUser(any(), any(Pageable.class)))
                 .willReturn(List.of(Track.builder().spotifyTrackId("test1").build(),
                         Track.builder().spotifyTrackId("test2").build()));
 

--- a/src/test/java/com/my/firstbeat/web/service/RecommendationServiceWithoutLockUnitTest.java
+++ b/src/test/java/com/my/firstbeat/web/service/RecommendationServiceWithoutLockUnitTest.java
@@ -40,7 +40,7 @@ import static org.mockito.Mockito.verify;
 @ExtendWith(MockitoExtension.class)
 @ActiveProfiles("test")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class TrackServiceTest extends DummyObject {
+class RecommendationServiceWithoutLockUnitTest extends DummyObject {
 
     @InjectMocks
     private RecommendationServiceWithoutLock recommendationService;
@@ -162,7 +162,7 @@ class TrackServiceTest extends DummyObject {
     }
 
     @Test
-    @DisplayName("여러 스레드가 동시에 캐시 리프레시 시도할 때 중복 리프레시 발생하지 않는지 테스트")
+    @DisplayName("여러 스레드가 동시에 캐시 리프레시 시도할 때 중복 리프레시 발생하는지 테스트")
     void getRecommendations_with_concurrent_refresh_requests_should_cause_duplicatedRefresh() throws InterruptedException {
 
         int concurrentRequests = 50;

--- a/src/test/java/com/my/firstbeat/web/service/TrackServiceTest.java
+++ b/src/test/java/com/my/firstbeat/web/service/TrackServiceTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class TrackServiceTest {
+  
+}

--- a/src/test/java/com/my/firstbeat/web/service/TrackServiceTest.java
+++ b/src/test/java/com/my/firstbeat/web/service/TrackServiceTest.java
@@ -2,7 +2,6 @@ package com.my.firstbeat.web.service;
 
 import com.my.firstbeat.client.spotify.SpotifyClient;
 import com.my.firstbeat.client.spotify.dto.response.RecommendationResponse;
-import com.my.firstbeat.client.spotify.dto.response.TrackSearchResponse;
 import com.my.firstbeat.web.controller.track.dto.response.TrackRecommendationResponse;
 import com.my.firstbeat.web.domain.genre.Genre;
 import com.my.firstbeat.web.domain.genre.GenreRepository;
@@ -11,9 +10,7 @@ import com.my.firstbeat.web.domain.track.Track;
 import com.my.firstbeat.web.domain.track.TrackRepository;
 import com.my.firstbeat.web.domain.user.Role;
 import com.my.firstbeat.web.domain.user.User;
-import com.my.firstbeat.web.domain.userGenre.UserGenreRepository;
 import com.my.firstbeat.web.dummy.DummyObject;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -23,11 +20,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
-
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -49,7 +43,7 @@ import static org.mockito.Mockito.verify;
 class TrackServiceTest extends DummyObject {
 
     @InjectMocks
-    private TrackService trackService;
+    private RecommendationServiceWithoutLock recommendationService;
 
     @Mock
     private SpotifyClient spotifyClient;
@@ -126,7 +120,7 @@ class TrackServiceTest extends DummyObject {
                                 threadName, userId, requestId, currentRequest);
 
 
-                        TrackRecommendationResponse response = trackService.getRecommendations(testUser.getId());
+                        TrackRecommendationResponse response = recommendationService.getRecommendations(testUser.getId());
                         if (response != null) {
                             recommendedTracks.add(response.getSpotifyTrackId());
                             System.out.printf("[%s] 요청 완료 - trackId: %s (user: %d, request: %d, 전체요청: %d)%n",
@@ -212,7 +206,7 @@ class TrackServiceTest extends DummyObject {
 
 
         //캐시 초기화를 위해 첫 번째 호출 수행
-        trackService.getRecommendations(testUser.getId());
+        recommendationService.getRecommendations(testUser.getId());
         //카운트 리셋
         apiCallCount.set(0);
 
@@ -224,7 +218,7 @@ class TrackServiceTest extends DummyObject {
             futures.add(executorService.submit(() ->{
                 startLatch.await();
                 try{
-                    return trackService.getRecommendations(testUser.getId());
+                    return recommendationService.getRecommendations(testUser.getId());
                 }finally {
                     completionLatch.countDown();
                 }

--- a/src/test/java/com/my/firstbeat/web/service/TrackServiceTest.java
+++ b/src/test/java/com/my/firstbeat/web/service/TrackServiceTest.java
@@ -1,39 +1,197 @@
 package com.my.firstbeat.web.service;
 
 import com.my.firstbeat.client.spotify.SpotifyClient;
+import com.my.firstbeat.client.spotify.dto.response.RecommendationResponse;
+import com.my.firstbeat.client.spotify.dto.response.TrackSearchResponse;
+import com.my.firstbeat.web.controller.track.dto.response.TrackRecommendationResponse;
+import com.my.firstbeat.web.domain.genre.Genre;
 import com.my.firstbeat.web.domain.playlist.PlaylistRepository;
+import com.my.firstbeat.web.domain.track.Track;
 import com.my.firstbeat.web.domain.track.TrackRepository;
+import com.my.firstbeat.web.domain.user.Role;
+import com.my.firstbeat.web.domain.user.User;
 import com.my.firstbeat.web.domain.userGenre.UserGenreRepository;
+import com.my.firstbeat.web.dummy.DummyObject;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.my.firstbeat.client.spotify.dto.response.TrackSearchResponse.*;
+import static com.my.firstbeat.client.spotify.dto.response.TrackSearchResponse.TrackResponse.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.verify;
 
-@SpringBootTest
-class TrackServiceTest {
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+class TrackServiceTest extends DummyObject {
 
-    @Autowired
+    @InjectMocks
+    private TrackService trackService;
+
+    @Mock
     private SpotifyClient spotifyClient;
-    @Autowired
+
+    @Mock
     private UserService userService;
-    @Autowired
+
+    @Mock
     private UserGenreRepository userGenreRepository;
-    @Autowired
+
+    @Mock
     private PlaylistRepository playlistRepository;
-    @Autowired
+
+    @Mock
     private TrackRepository trackRepository;
 
+    private User testUser;
+    private static final int CONCURRENT_USERS = 10;
+    private static final int REQUESTS_PER_USER = 5;
+
+    @BeforeEach
+    void setUp() {
+        testUser = new User(1L, "test@naver.com", Role.USER);
+
+        given(userService.findByIdOrFail(testUser.getId())).willReturn(testUser);
+
+        given(trackRepository.existsInUserPlaylist(any(), anyString())).willReturn(false);
+
+        given(userGenreRepository.findTop5GenresByUser(any()))
+                .willReturn(List.of(new Genre("pop"), new Genre("rock")));
+        given(playlistRepository.findAllTrackByUser(any()))
+                .willReturn(List.of(Track.builder().spotifyTrackId("test1").build(), Track.builder().spotifyTrackId("test2").build()));
+
+        RecommendationResponse mockRecommendation = new RecommendationResponse();
+        List<TrackResponse> tracks = IntStream.range(0, 20)
+                .mapToObj(i -> builder()
+                        .id("spotifyId: "+i)
+                        .artists(new ArtistResponse("nct wish"))
+                        .build())
+                .collect(Collectors.toList());
+
+        mockRecommendation.setTracks(tracks);
+
+        given(spotifyClient.getRecommendations(anyString(), anyString(), anyInt()))
+                .willAnswer(invocation -> {
+                    RecommendationResponse response = new RecommendationResponse();
+                    response.setTracks(tracks);
+                    return response;
+                });
+    }
+
     @Test
-    @DisplayName("동일 유저에 대한 동시 추천 요청 테스트")
-    void getRecommendations_concurrency_test(){
+    @DisplayName("여러 사용자가 동시에 추천 요청 테스트: 여러 스레드가 동시에 캐시에 접근할 때 안전한지 확인")
+    void getRecommendations_with_multiple_threads_requests() throws InterruptedException {
+        ExecutorService executorService = Executors.newFixedThreadPool(CONCURRENT_USERS); //10개
+        CountDownLatch latch = new CountDownLatch(CONCURRENT_USERS * REQUESTS_PER_USER); //10*5 = 50번
+        List<Future<TrackRecommendationResponse>> futures = new ArrayList<>(); //비동기 결과 저장해야 함
+        Set<String> recommendedTracks = Collections.synchronizedSet(new HashSet<>());
+        AtomicInteger requestCount = new AtomicInteger(0);
 
-        int threads = 5;
-        Long userId = 1L;
+        for(int user = 0; user < CONCURRENT_USERS; user++){
+            final int userId = user;
+            for(int request = 0; request<REQUESTS_PER_USER; request++){
+                final int requestId = request;
+                futures.add(executorService.submit(() -> {
+                    try{
 
+                        int currentRequest = requestCount.incrementAndGet();
+                        String threadName = Thread.currentThread().getName();
+                        System.out.printf("[%s] 요청 시작 (user: %d, request: %d, 전체요청: %d)%n",
+                                threadName, userId, requestId, currentRequest);
+
+
+                        TrackRecommendationResponse response = trackService.getRecommendations(testUser.getId());
+                        if (response != null) {
+                            recommendedTracks.add(response.getSpotifyTrackId());
+                            System.out.printf("[%s] 요청 완료 - trackId: %s (user: %d, request: %d, 전체요청: %d)%n",
+                                    threadName, response.getSpotifyTrackId(), userId, requestId, currentRequest);
+                        }
+                        return response;
+                    }finally {
+                        latch.countDown();
+                    }
+                }));
+            }
+        }
+
+        assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+        executorService.shutdown();
+
+        List<TrackRecommendationResponse> results = new ArrayList<>();
+        for (Future<TrackRecommendationResponse> future : futures) {
+            try {
+                TrackRecommendationResponse response = future.get(1, TimeUnit.SECONDS);
+                if (response != null) {
+                    results.add(response);
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+                throw new RuntimeException("Future.get() 실행 중 에러 발생", e);
+            }
+        }
+
+        //요청은 누락되면 안됨
+        assertThat(results)
+                .hasSize(CONCURRENT_USERS * REQUESTS_PER_USER)
+                .doesNotContainNull();
+
+
+        //최소 3번은 spotifyClient 에 추천 리스트 조회 요청 보내야 함
+        int expectedMinRefreshes = (CONCURRENT_USERS * REQUESTS_PER_USER) / 20 + 1;
+        verify(spotifyClient, atLeast(expectedMinRefreshes)).getRecommendations(anyString(), anyString(), anyInt());
+    }
+
+    @Test
+    @DisplayName("여러 스레드가 동시에 캐시 리프레시 시도할 때 중복 리프레시 발생하지 않는지 테스트")
+    void getRecommendations_with_concurrent_refresh_requests_shouldNot_duplicatedRefresh(){
+
+        int concurrentRequests = 50;
+        ExecutorService executorService = Executors.newFixedThreadPool(concurrentRequests); //10개
+        CountDownLatch latch = new CountDownLatch(1); //10*5 = 50번
+        CountDownLatch completionLatch = new CountDownLatch(concurrentRequests);
+
+        given(spotifyClient.getRecommendations(anyString(), anyString(), anyInt()))
+                .willAnswer(invocation -> {
+                    Thread.sleep(100);
+                    RecommendationResponse response = new RecommendationResponse();
+
+                    List<TrackResponse> tracks = IntStream.range(0, 20)
+                            .mapToObj(i -> builder()
+                                    .id("spotifyId: "+i)
+                                    .artists(new ArtistResponse("nct wish"))
+                                    .build())
+                            .collect(Collectors.toList());
+
+                    response.setTracks(tracks);
+                    return response;
+                });
+
+        List<Future<TrackRecommendationResponse>> futures = new ArrayList<>();
+        for(int i = 0;i<concurrentRequests; i++){
+
+        }
 
     }
+
+
+
 
 
 }

--- a/src/test/java/com/my/firstbeat/web/service/TrackServiceTest.java
+++ b/src/test/java/com/my/firstbeat/web/service/TrackServiceTest.java
@@ -1,4 +1,39 @@
+package com.my.firstbeat.web.service;
+
+import com.my.firstbeat.client.spotify.SpotifyClient;
+import com.my.firstbeat.web.domain.playlist.PlaylistRepository;
+import com.my.firstbeat.web.domain.track.TrackRepository;
+import com.my.firstbeat.web.domain.userGenre.UserGenreRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
 import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
 class TrackServiceTest {
-  
+
+    @Autowired
+    private SpotifyClient spotifyClient;
+    @Autowired
+    private UserService userService;
+    @Autowired
+    private UserGenreRepository userGenreRepository;
+    @Autowired
+    private PlaylistRepository playlistRepository;
+    @Autowired
+    private TrackRepository trackRepository;
+
+    @Test
+    @DisplayName("동일 유저에 대한 동시 추천 요청 테스트")
+    void getRecommendations_concurrency_test(){
+
+        int threads = 5;
+        Long userId = 1L;
+
+
+    }
+
+
 }


### PR DESCRIPTION
## 시나리오
1. 해당 사용자 검증 -> 존재하지 않으면 에러 throw
2. 사용자의 선호 장르 리스트 조회 -> 존재하지 않으면 에러 throw
3. 사용자의 모든 플레이리스트에 있는 트랙 5개 랜덤 조회 -> 트랙이 존재하지 않으면 빈 값으로 대체
4. 추천 트랙 요청 및 캐싱
    - Spotify API 호출: 20개 트랙 요청 (RECOMMENDATIONS_SIZE = 20)
    - 중복 제거: 사용자 플레이리스트 내 존재 여부 확인
    - 캐시 저장: Caffeine Cache 활용
5. 캐시 갱신
    - 갱신 임계값: 5개 이하 시 갱신 (REFRESH_THRESHOLD = 5)
    - 최대 재시도: 20회 (MAX_ATTEMPTS = 20)

## 추천 트랙 조회 시의 동시성 이슈
추천 트랙 로직 중
```
if(recommendations.size() <= REFRESH_THRESHOLD) {
    refreshRecommendations(user);
    //갱신 후 캐시에서 추천 리스트 다시 가져옴
    recommendations = recommendationsCache.get(userId, key -> new ConcurrentLinkedQueue<>());
}
```
위 경우에서 동일 사용자의 여러 스레드가 접근할 시 원자성을 보장받지 못해 API 중복 호출이 발생해서 ReentrantLock을 사용해 동일 사용자의 SpotifyAPI 중복 호출을 제어했습니다

ReentrantLock을 사용한 이유는 동일 유저의 락 획득 시 데드락을 피하기 위함입니다

현재 ReentrantLock인 userLock은 유저 ID를 키로 사용하기 때문에 

userId = 1인 유저에 대해 스레드 A, B, C가 동시에 요청이 들어오면 모든 스레드가 userId = 1에 매핑된 동일한 하나의 ReentrantLock 인스턴스를 공유하게 됩니다

따라서 스레드 A가 락을 획득하면 B, C는 대기하게 되고, 반면 userId = 2인 유저의 요청은 별도의 락을 사용함으로써 영향이 없습니다

## 인메모리 캐시
CaffienCache를 사용해 lock-free를 구현했습니다
추천 데이터는 시간 기반 만료와 메모리 최대 크기 제한에 기반해 해당 캐시에서 관리됩니다
해당 설정은 CacheConfig에 등록했습니다

CaffienCache와 ConcurrentLinkedQueue를 조합해 사용해서 추천 트랙 조기 반환 시 명시적 락 없이 스레드 안정성을 보장하면서 조회가 가능하게 동작하고 있습니다

1시간 주기로 userLock 클린업 작업을 수행하며 조건은 다음과 같습니다
- 24시간 전에 캐시에 들어온 userId의 추천 데이터 존재
- 24시간이 지난 후 해당 userId의 캐시 접근 기록이 없으면 해당 데이터 삭제

## 백그라운드 추천 트랙 갱신
- backgroundRefresh()
10분 주기로 캐시에 있는 데이터 중 5개(임계값) 이하인 ConcurrentMap을 찾아 20개로 갱신하는 작업을 진행하고 있습니다
해당 작업은 실패 시 내용과 실패 카운트를 로깅하고 있습니다

## 테스트
### RecommendationServiceWithoutLockUnitTest & RecommendationServiceWithoutLockTest
: 초기 락을 사용하지 않고 구현한 코드에서 동시성 이슈를 확인하기 위해 진행
- 여러 사용자가 동시에 추천 요청 테스트: 여러 스레드가 동시에 캐시에 접근할 때 안전한지 확인
- 여러 스레드가 동시에 캐시 리프레시 시도할 때 중복 API 호출 발생 테스트 및 예상 값을 뛰어넘는 중복 호출 확인
- 스프링부트 테스트도 같이 진행하여 실제 중복 호출 확인

### RecommendationServiceUnitTest
: 락을 추가하여 중복 API 호출이 일어나지 않는지를 메인으로 확인
- 추천 트랙 조회: 캐시에 충분한 추천곡이 있고, 플레이리스트에 없는 경우 즉시 반환
- 추천 트랙 조회: 캐시에 데이터가 부족할 시 새로운 추천 트랙 리스트 요청
- 추천 트랙 조회: 캐시에 데이터가 있지만 모두 플레이리스트에 존재하는 경우 새로운 추천
- 추천 트랙 조회: 최대 재시도 횟수(빠른 반환을 위한 초기 호출1 + 최대 횟수20) 초과 시 예외 발생
- 백그라운드 추천 트랙 리프레시: 정상 동작 확인
- 캐시 리프레시 조건 확인




