### PR TITLE
플레이리스트 내 트랙 목록 조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,3 +52,7 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+compileJava {
+    options.compilerArgs << '-parameters'
+}

--- a/src/main/java/com/my/firstbeat/web/controller/playlist/PlaylistController.java
+++ b/src/main/java/com/my/firstbeat/web/controller/playlist/PlaylistController.java
@@ -55,9 +55,10 @@ public class PlaylistController {
 	}
 
 	@GetMapping("/{playlistId}")
-	public ResponseEntity<ApiResult<TrackListResponse>> getTrackList(@PathVariable(value = "playlistId") Long playlistId,
-																	 @RequestParam(value = "page", defaultValue = "0", required = false) @PositiveOrZero int page,
-																	 @RequestParam(value = "size", defaultValue = "10", required = false) @Range(min = 1, max = 100, message = "페이지 크기는 1에서 100 사이여야 합니다") int size) {
+	public ResponseEntity<ApiResult<TrackListResponse>> getTrackList(
+			@PathVariable(value = "playlistId") Long playlistId,
+		    @RequestParam(value = "page", defaultValue = "0", required = false) @PositiveOrZero int page,
+		    @RequestParam(value = "size", defaultValue = "10", required = false) @Range(min = 1, max = 100, message = "페이지 크기는 1에서 100 사이여야 합니다") int size) {
 		return ResponseEntity.ok(ApiResult.success(playlistService.getTrackList(playlistId, page, size)));
 	}
 }

--- a/src/main/java/com/my/firstbeat/web/controller/playlist/PlaylistController.java
+++ b/src/main/java/com/my/firstbeat/web/controller/playlist/PlaylistController.java
@@ -10,6 +10,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.validator.constraints.Range;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
@@ -56,7 +57,7 @@ public class PlaylistController {
 	@GetMapping("/{playlistId}")
 	public ResponseEntity<ApiResult<TrackListResponse>> getTrackList(@PathVariable(value = "playlistId") Long playlistId,
 																	 @RequestParam(value = "page", defaultValue = "0", required = false) @PositiveOrZero int page,
-																	 @RequestParam(value = "size", defaultValue = "10", required = false) @Positive int size){
-		return ResponseEntity.of(playlistService.getTrackList(playlistId, page, size));
+																	 @RequestParam(value = "size", defaultValue = "10", required = false) @Range(min = 1, max = 100, message = "페이지 크기는 1에서 100 사이여야 합니다") int size) {
+		return ResponseEntity.ok(ApiResult.success(playlistService.getTrackList(playlistId, page, size)));
 	}
 }

--- a/src/main/java/com/my/firstbeat/web/controller/playlist/PlaylistController.java
+++ b/src/main/java/com/my/firstbeat/web/controller/playlist/PlaylistController.java
@@ -3,19 +3,17 @@ package com.my.firstbeat.web.controller.playlist;
 import com.my.firstbeat.web.config.security.loginuser.LoginUser;
 import com.my.firstbeat.web.controller.playlist.dto.request.PlaylistCreateRequest;
 import com.my.firstbeat.web.controller.playlist.dto.response.PlaylistCreateResponse;
+import com.my.firstbeat.web.controller.playlist.dto.response.TrackListResponse;
 import com.my.firstbeat.web.service.PlaylistService;
 import com.my.firstbeat.web.util.api.ApiResult;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
 import com.my.firstbeat.web.config.security.loginuser.LoginUser;
 import com.my.firstbeat.web.domain.playlist.Playlist;
 import com.my.firstbeat.web.service.PlaylistService;
@@ -24,6 +22,7 @@ import com.my.firstbeat.web.util.api.ApiResult;
 @RestController
 @RequestMapping("/api/v1/playlist")
 @RequiredArgsConstructor
+@Validated
 public class PlaylistController {
 
     private final PlaylistService playlistService;
@@ -48,9 +47,16 @@ public class PlaylistController {
 	// 디폴트 플레이리스트 변경
 	@PutMapping("/{playlistId}/default/")
 	public ResponseEntity<ApiResult<String>> changeDefaultPlaylist(
-		@PathVariable Long playlistId,
+		@PathVariable(value = "playlistId") Long playlistId,
 		@AuthenticationPrincipal LoginUser user) {
 		playlistService.changeDefaultPlaylist(user.getUser().getId(), playlistId);
 		return ResponseEntity.ok(ApiResult.success("디폴트 플레이리스트가 변경되었습니다."));
+	}
+
+	@GetMapping("/{playlistId}")
+	public ResponseEntity<ApiResult<TrackListResponse>> getTrackList(@PathVariable(value = "playlistId") Long playlistId,
+																	 @RequestParam(value = "page", defaultValue = "0", required = false) @PositiveOrZero int page,
+																	 @RequestParam(value = "size", defaultValue = "10", required = false) @Positive int size){
+		return ResponseEntity.of(playlistService.getTrackList(playlistId, page, size));
 	}
 }

--- a/src/main/java/com/my/firstbeat/web/controller/playlist/dto/response/TrackListResponse.java
+++ b/src/main/java/com/my/firstbeat/web/controller/playlist/dto/response/TrackListResponse.java
@@ -1,8 +1,10 @@
 package com.my.firstbeat.web.controller.playlist.dto.response;
 
 import com.my.firstbeat.client.spotify.dto.response.TrackSearchResponse;
+import com.my.firstbeat.web.domain.track.Track;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 
@@ -11,10 +13,30 @@ import java.util.List;
 public class TrackListResponse {
 
     private List<TrackResponse> tracks;
+    private long totalElements;
+    private int totalPages;
+    private boolean hasPrevious;
+    private boolean hasNext;
+
+    public TrackListResponse(Page<Track> trackPage) {
+        this.tracks = trackPage.getContent().stream().map(TrackResponse::new).toList();
+        this.totalElements = trackPage.getTotalElements();
+        this.totalPages = trackPage.getTotalPages();
+        this.hasPrevious = trackPage.hasPrevious();
+        this.hasNext = trackPage.hasNext();
+    }
 
     @NoArgsConstructor
     @Getter
     public static class TrackResponse{
+        public TrackResponse(Track track) {
+            this.id = track.getId();
+            this.trackName = track.getName();
+            this.artistName = track.getArtistName();
+            this.albumCoverUrl = track.getPreviewUrl();
+            this.previewUrl = track.getPreviewUrl();
+        }
+
         private Long id;
         private String trackName;
         private String artistName;

--- a/src/main/java/com/my/firstbeat/web/controller/playlist/dto/response/TrackListResponse.java
+++ b/src/main/java/com/my/firstbeat/web/controller/playlist/dto/response/TrackListResponse.java
@@ -1,0 +1,25 @@
+package com.my.firstbeat.web.controller.playlist.dto.response;
+
+import com.my.firstbeat.client.spotify.dto.response.TrackSearchResponse;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor
+@Getter
+public class TrackListResponse {
+
+    private List<TrackResponse> tracks;
+
+    @NoArgsConstructor
+    @Getter
+    public static class TrackResponse{
+        private Long id;
+        private String trackName;
+        private String artistName;
+        private String albumCoverUrl;
+        private String previewUrl;
+    }
+
+}

--- a/src/main/java/com/my/firstbeat/web/domain/playlist/Playlist.java
+++ b/src/main/java/com/my/firstbeat/web/domain/playlist/Playlist.java
@@ -3,14 +3,13 @@ package com.my.firstbeat.web.domain.playlist;
 import com.my.firstbeat.web.domain.base.BaseEntity;
 import com.my.firstbeat.web.domain.user.User;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class Playlist extends BaseEntity {
 
     @Id

--- a/src/main/java/com/my/firstbeat/web/domain/track/Track.java
+++ b/src/main/java/com/my/firstbeat/web/domain/track/Track.java
@@ -2,14 +2,14 @@ package com.my.firstbeat.web.domain.track;
 
 import com.my.firstbeat.web.domain.base.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.Columns;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class Track extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/my/firstbeat/web/domain/track/TrackRepository.java
+++ b/src/main/java/com/my/firstbeat/web/domain/track/TrackRepository.java
@@ -10,6 +10,6 @@ import org.springframework.data.repository.query.Param;
 
 public interface TrackRepository extends JpaRepository<Track, Long> {
 
-    @Query("select t from Track t join PlaylistTrack pt on pt.playlist = :playlist order by pt.createdAt desc")
+    @Query("select t from Track t join PlaylistTrack pt on pt.track = t where pt.playlist = :playlist order by pt.createdAt desc")
     Page<Track> findAllByPlaylist(@Param("playlist")Playlist playlist, Pageable pageable);
 }

--- a/src/main/java/com/my/firstbeat/web/domain/track/TrackRepository.java
+++ b/src/main/java/com/my/firstbeat/web/domain/track/TrackRepository.java
@@ -1,6 +1,15 @@
 package com.my.firstbeat.web.domain.track;
 
+import com.my.firstbeat.web.domain.playlist.Playlist;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.data.repository.query.Param;
 
 public interface TrackRepository extends JpaRepository<Track, Long> {
+
+    @Query("select t from Track t join PlaylistTrack pt on pt.playlist = :playlist order by pt.createdAt desc")
+    Page<Track> findAllByPlaylist(@Param("playlist")Playlist playlist, Pageable pageable);
 }

--- a/src/main/java/com/my/firstbeat/web/ex/ErrorCode.java
+++ b/src/main/java/com/my/firstbeat/web/ex/ErrorCode.java
@@ -8,8 +8,8 @@ public enum ErrorCode {
 
     USER_NOT_FOUND("Access denied for user data", HttpStatus.SC_FORBIDDEN), // UserId를 통해 해당 유저가 존재하는지 하지 않는지 파악하는것을 막기위해 403 코드로 적용
     DUPLICATE_PLAYLIST_TITLE("이미 존재하는 제목입니다.", HttpStatus.SC_CONFLICT),
-    PLAYLIST_NOT_FOUND("존재하지 않는 플레이리스트입니다", HttpStatus.SC_NOT_FOUND)
-    ;
+    PLAYLIST_NOT_FOUND("존재하지 않는 플레이리스트입니다", HttpStatus.SC_NOT_FOUND),
+    TRACK_FETCH_ERROR("플레이리스트 내 트랙 목록을 불러오는 중 오류가 발생했습니다", HttpStatus.SC_INTERNAL_SERVER_ERROR);
 
     private final String message;
     private final int status;

--- a/src/main/java/com/my/firstbeat/web/ex/ErrorCode.java
+++ b/src/main/java/com/my/firstbeat/web/ex/ErrorCode.java
@@ -8,6 +8,7 @@ public enum ErrorCode {
 
     USER_NOT_FOUND("Access denied for user data", HttpStatus.SC_FORBIDDEN), // UserId를 통해 해당 유저가 존재하는지 하지 않는지 파악하는것을 막기위해 403 코드로 적용
     DUPLICATE_PLAYLIST_TITLE("이미 존재하는 제목입니다.", HttpStatus.SC_CONFLICT),
+    PLAYLIST_NOT_FOUND("존재하지 않는 플레이리스트입니다", HttpStatus.SC_NOT_FOUND)
     ;
 
     private final String message;

--- a/src/main/java/com/my/firstbeat/web/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/my/firstbeat/web/handler/GlobalExceptionHandler.java
@@ -4,7 +4,7 @@ import com.my.firstbeat.web.ex.BusinessException;
 import com.my.firstbeat.web.util.api.ApiError;
 import com.my.firstbeat.web.util.api.ApiResult;
 import lombok.extern.slf4j.Slf4j;
-import org.hibernate.exception.ConstraintViolationException;
+import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
@@ -57,13 +57,15 @@ public class GlobalExceptionHandler {
     }
 
 
-        //TODO 쿼리 파라미터 객체로 받는 경우 생긴다면 추가하기
-//    @ExceptionHandler(ConstraintViolationException.class)
-//    public ResponseEntity<ApiResult<Map<String, String>>> queryParameterValidationException(ConstraintViolationException e) {
-//        Map<String, String> errorMap = new HashMap<>();
-//        e.getConstraintViolations().forEach(error ->
-//                errorMap.put(((PathImpl) (error.getPropertyPath())).getLeafNode().getName(), error.getMessage()));
-//        return new ResponseEntity<>(ApiResult.error(HttpStatus.BAD_REQUEST.value(), "유효성 검사 실패", errorMap), HttpStatus.BAD_REQUEST);
-//    }
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiResult<Map<String, String>>> queryParameterValidationException(ConstraintViolationException e) {
+        Map<String, String> errorMap = new HashMap<>();
+        e.getConstraintViolations().forEach(error -> {
+            String propertyPath = error.getPropertyPath().toString();
+            String fieldName = propertyPath.substring(propertyPath.lastIndexOf('.') + 1);
+            errorMap.put(fieldName, error.getMessage());
+        });
+        return new ResponseEntity<>(ApiResult.error(HttpStatus.BAD_REQUEST.value(), "유효성 검사 실패", errorMap), HttpStatus.BAD_REQUEST);
+    }
 
 }

--- a/src/main/java/com/my/firstbeat/web/service/PlaylistService.java
+++ b/src/main/java/com/my/firstbeat/web/service/PlaylistService.java
@@ -2,12 +2,17 @@ package com.my.firstbeat.web.service;
 
 import com.my.firstbeat.web.controller.playlist.dto.request.PlaylistCreateRequest;
 import com.my.firstbeat.web.controller.playlist.dto.response.PlaylistCreateResponse;
+import com.my.firstbeat.web.controller.playlist.dto.response.TrackListResponse;
 import com.my.firstbeat.web.domain.playlist.Playlist;
 import com.my.firstbeat.web.domain.playlist.PlaylistRepository;
+import com.my.firstbeat.web.domain.track.TrackRepository;
 import com.my.firstbeat.web.domain.user.User;
 import com.my.firstbeat.web.domain.user.UserRepository;
 import com.my.firstbeat.web.ex.BusinessException;
 import com.my.firstbeat.web.ex.ErrorCode;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +26,7 @@ public class PlaylistService {
 
     private final PlaylistRepository playlistRepository;
   	private final UserRepository userRepository;
+    private final TrackRepository trackRepository;
 
     @Transactional
     public PlaylistCreateResponse createPlaylist(User user, PlaylistCreateRequest request) {
@@ -77,6 +83,18 @@ public class PlaylistService {
 		// 새로운 defalut를 세팅
 		newDefaultPlaylist.updateDefault(true);
 		playlistRepository.save(newDefaultPlaylist);
+	}
+
+	public TrackListResponse getTrackList(Long playlistId, int page, int size) {
+		Playlist playlist = findByIdOrFail(playlistId);
+		Pageable pageable = PageRequest.of(page, size);
+		trackRepository.findAllByPlaylist(playlist, pageable);
+
+	}
+
+	public Playlist findByIdOrFail(Long playlistId){
+		return playlistRepository.findById(playlistId)
+				.orElseThrow(() -> new BusinessException(ErrorCode.PLAYLIST_NOT_FOUND));
 	}
 }
 

--- a/src/main/java/com/my/firstbeat/web/service/PlaylistService.java
+++ b/src/main/java/com/my/firstbeat/web/service/PlaylistService.java
@@ -5,11 +5,13 @@ import com.my.firstbeat.web.controller.playlist.dto.response.PlaylistCreateRespo
 import com.my.firstbeat.web.controller.playlist.dto.response.TrackListResponse;
 import com.my.firstbeat.web.domain.playlist.Playlist;
 import com.my.firstbeat.web.domain.playlist.PlaylistRepository;
+import com.my.firstbeat.web.domain.track.Track;
 import com.my.firstbeat.web.domain.track.TrackRepository;
 import com.my.firstbeat.web.domain.user.User;
 import com.my.firstbeat.web.domain.user.UserRepository;
 import com.my.firstbeat.web.ex.BusinessException;
 import com.my.firstbeat.web.ex.ErrorCode;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -88,8 +90,13 @@ public class PlaylistService {
 	public TrackListResponse getTrackList(Long playlistId, int page, int size) {
 		Playlist playlist = findByIdOrFail(playlistId);
 		Pageable pageable = PageRequest.of(page, size);
-		trackRepository.findAllByPlaylist(playlist, pageable);
-
+		try {
+			Page<Track> trackPage = trackRepository.findAllByPlaylist(playlist, pageable);
+			return new TrackListResponse(trackPage);
+		} catch(Exception e){
+			log.error("플레이리스트 내 트랙 목록 조회 시 오류 발생: 플레이리스트 ID: {}, 원인: {}", playlistId, e.getMessage(), e);
+			throw new BusinessException(ErrorCode.TRACK_FETCH_ERROR);
+		}
 	}
 
 	public Playlist findByIdOrFail(Long playlistId){

--- a/src/test/java/com/my/firstbeat/web/controller/playlist/PlaylistControllerTest.java
+++ b/src/test/java/com/my/firstbeat/web/controller/playlist/PlaylistControllerTest.java
@@ -1,0 +1,98 @@
+package com.my.firstbeat.web.controller.playlist;
+
+import com.my.firstbeat.web.config.security.loginuser.LoginUser;
+import com.my.firstbeat.web.config.security.loginuser.LoginUserService;
+import com.my.firstbeat.web.controller.playlist.dto.response.TrackListResponse;
+import com.my.firstbeat.web.controller.track.TrackController;
+import com.my.firstbeat.web.domain.track.Track;
+import com.my.firstbeat.web.domain.user.User;
+import com.my.firstbeat.web.dummy.DummyObject;
+import com.my.firstbeat.web.service.PlaylistService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PlaylistController.class)
+class PlaylistControllerTest extends DummyObject {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private PlaylistService playlistService;
+    @MockBean
+    private LoginUserService  loginUserService;
+
+    private LoginUser loginUser;
+
+    @BeforeEach
+    void setUp() {
+        loginUser = new LoginUser(mockUser());
+
+        given(loginUserService.loadUserByUsername(anyString()))
+                .willReturn(loginUser);
+    }
+
+    @Test
+    @WithMockUser(username = "test1234@naver.com")
+    @DisplayName("플레이리스트 내 트랙 목록 조회: 정상 케이스")
+    void getTrackList_success() throws Exception {
+        Long playlistId = 1L;
+        int page = 0;
+        int size = 10;
+
+        List<Track> tracks = Arrays.asList(
+                Track.builder()
+                        .name("노래 제목")
+                        .spotifyTrackId("spotifyTrackId")
+                        .albumCoverUrl("url")
+                        .previewUrl("url")
+                        .artistName("NctWish")
+                        .build(),
+                Track.builder()
+                        .name("노래 제목1")
+                        .spotifyTrackId("spotifyTrackId1")
+                        .albumCoverUrl("url1")
+                        .previewUrl("url1")
+                        .artistName("NctWish1")
+                        .build()
+        );
+        Page<Track> trackPage = new PageImpl<>(tracks);
+        TrackListResponse response = new TrackListResponse(trackPage);
+
+        given(playlistService.getTrackList(playlistId, page, size))
+                .willReturn(response);
+
+        mockMvc.perform(get("/api/v1/playlist/{playlistId}", playlistId)
+                        .param("page", String.valueOf(page))
+                        .param("size", String.valueOf(size))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").exists())
+                .andDo(print());
+    }
+
+}

--- a/src/test/java/com/my/firstbeat/web/controller/playlist/PlaylistControllerTest.java
+++ b/src/test/java/com/my/firstbeat/web/controller/playlist/PlaylistControllerTest.java
@@ -95,4 +95,16 @@ class PlaylistControllerTest extends DummyObject {
                 .andDo(print());
     }
 
+    @Test
+    @WithMockUser(username = "test1234@naver.com")
+    @DisplayName("플레이리스트 내 트랙 목록 조회: 100을 넘어선 사이즈로 요청을 보내는 경우 유효성 검사 오류")
+    void getTrackList_invalid_pageSize() throws Exception {
+        mockMvc.perform(get("/api/v1/playlist/1")
+                        .param("page", "0")
+                        .param("size", "101")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andDo(print());
+    }
+
 }

--- a/src/test/java/com/my/firstbeat/web/service/PlaylistServiceTest.java
+++ b/src/test/java/com/my/firstbeat/web/service/PlaylistServiceTest.java
@@ -233,6 +233,33 @@ class PlaylistServiceTest extends DummyObject {
 		verify(trackRepository, never()).findAllByPlaylist(any(), any());
 	}
 
+	@Test
+	@DisplayName("플레이리스트 내 추천 트랙 반환: 트랙 조회 중 에러 발생 시 BusinessException throw")
+	void getTrackList_TrackFetchError() {
+		Long playlistId = 1L;
+		Playlist playlist = Playlist.builder()
+				.title("나만의 플레이리스트")
+				.id(playlistId)
+				.description("내꺼")
+				.build();
+
+		PlaylistService realService = new PlaylistService(playlistRepository, userRepository, trackRepository);
+		PlaylistService spyService = spy(realService);
+
+		doReturn(playlist).when(spyService).findByIdOrFail(playlistId);
+		when(trackRepository.findAllByPlaylist(any(), any()))
+				.thenThrow(new RuntimeException("DB 에러"));
+
+		// when & then
+		BusinessException exception = assertThrows(BusinessException.class, () ->
+				spyService.getTrackList(playlistId, 0, 10));
+
+		assertEquals(ErrorCode.TRACK_FETCH_ERROR, exception.getErrorCode());
+		verify(trackRepository).findAllByPlaylist(any(), any());
+	}
+
+
+
 
 }
 


### PR DESCRIPTION
## 시나리오
- /api/v1/playlists/{playlistId}
다른 사용자의 플레이리스트 내 트랙 리스트도 조회 가능해야 하기 때문에 LoginUser를 사용하지 않고 진행

1. 플레이리스트 내 전체 트랙 조회 요청
2. 해당 플레이리스트가 존재하는지 확인 -> 존재하지 않을 시 에러 throw
3. 플레이리스트 내 전체 트랙 조회 (페이징 같이 진행) -> 오류 발생 시 에러 throw 
4. 응답 값 반환

## 테스트
### 서비스 단위 테스트
- 플레이리스트 내 추천 트랙 반환: 정상 케이스
- 플레이리스트 내 추천 트랙 반환: 존재하지 않는 플레이리스트 조회 시 예외 발생
- 플레이리스트 내 추천 트랙 반환: 트랙 조회 중 에러 발생 시 BusinessException throw
### 컨트롤러 단위 테스트
- 플레이리스트 내 트랙 목록 조회: 정상 케이스
- 플레이리스트 내 트랙 목록 조회: 100을 넘어선 사이즈로 요청을 보내는 경우 유효성 검사 오류