### PR TITLE
회원가입 기능 구현

### DIFF
--- a/src/main/java/com/my/firstbeat/web/config/jwt/JwtUtil.java
+++ b/src/main/java/com/my/firstbeat/web/config/jwt/JwtUtil.java
@@ -8,6 +8,7 @@ import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.annotation.Id;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 

--- a/src/main/java/com/my/firstbeat/web/config/security/SecurityConfig.java
+++ b/src/main/java/com/my/firstbeat/web/config/security/SecurityConfig.java
@@ -60,7 +60,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)// csrf 비활성화
                 .cors(cors -> cors.configurationSource(configurationSource()))
                 .authorizeHttpRequests(authorize ->  authorize
-                        .requestMatchers("/auth/**").permitAll()
+                        .requestMatchers("/api/v1/auth/register").permitAll()
                         .anyRequest().authenticated()
                 )
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) //jwt 사용

--- a/src/main/java/com/my/firstbeat/web/controller/playlist/PlaylistController.java
+++ b/src/main/java/com/my/firstbeat/web/controller/playlist/PlaylistController.java
@@ -18,12 +18,18 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @RestController
-@RequestMapping("/api/v1/playlist")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 @Validated
 public class PlaylistController {
@@ -64,13 +70,13 @@ public class PlaylistController {
         return ResponseEntity.ok(ApiResult.success("디폴트 플레이리스트가 변경되었습니다."));
     }
 
-    @GetMapping("/{playlistId}")
-    public ResponseEntity<ApiResult<TrackListResponse>> getTrackList(
-            @PathVariable(value = "playlistId") Long playlistId,
-            @RequestParam(value = "page", defaultValue = "0", required = false) @PositiveOrZero int page,
-            @RequestParam(value = "size", defaultValue = "10", required = false) @Range(min = 1, max = 100, message = "페이지 크기는 1에서 100 사이여야 합니다") int size) {
-        return ResponseEntity.ok(ApiResult.success(playlistService.getTrackList(playlistId, page, size)));
-    }
+	@GetMapping("/{playlistId}")
+	public ResponseEntity<ApiResult<TrackListResponse>> getTrackList(
+			@PathVariable(value = "playlistId") Long playlistId,
+		    @RequestParam(value = "page", defaultValue = "0", required = false) @PositiveOrZero int page,
+		    @RequestParam(value = "size", defaultValue = "10", required = false) @Range(min = 1, max = 100, message = "페이지 크기는 1에서 100 사이여야 합니다") int size) {
+		return ResponseEntity.ok(ApiResult.success(playlistService.getTrackList(playlistId, page, size)));
+	}
 
     @GetMapping("/v1/playlist")
     public ResponseEntity<ApiResult<PlaylistsData>> getPlaylists(
@@ -98,5 +104,15 @@ public class PlaylistController {
         );
 
         return ResponseEntity.ok(ApiResult.success(new PlaylistsData(playlists, pagination)));
+    }
+
+    @DeleteMapping("{playlistId}")
+    public ResponseEntity<ApiResult<String>> deletePlaylist(
+            @PathVariable Long playlistId,
+            @AuthenticationPrincipal LoginUser user) {
+        // 현재 로그인한 사용자와 Playlist ID를 서비스로 전달
+        playlistService.deletePlaylist(user.getUser().getId(), playlistId);
+        // 성공 응답 반환
+        return ResponseEntity.ok(ApiResult.success("플레이리스트가 삭제되었습니다."));
     }
 }

--- a/src/main/java/com/my/firstbeat/web/controller/user/UserController.java
+++ b/src/main/java/com/my/firstbeat/web/controller/user/UserController.java
@@ -1,6 +1,7 @@
 package com.my.firstbeat.web.controller.user;
 
 import com.my.firstbeat.web.config.security.loginuser.LoginUser;
+import com.my.firstbeat.web.controller.user.dto.request.SignupRequestDto;
 import com.my.firstbeat.web.controller.user.dto.request.UpdateMyPageRequest;
 import com.my.firstbeat.web.controller.user.dto.response.GetMyPageResponse;
 import com.my.firstbeat.web.controller.user.dto.response.UpdateMyPageResponse;
@@ -14,12 +15,18 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/users")
+@RequestMapping("/api/v1")
 public class UserController {
 
     private final UserService userService;
 
-    @GetMapping("/mypage")
+    @PostMapping("/auth/register")
+    public ResponseEntity<ApiResult> signup(@Valid @RequestBody SignupRequestDto signupRequestDto) {
+        String message = userService.signup(signupRequestDto);
+        return ResponseEntity.ok(ApiResult.success(message));
+    }
+
+    @GetMapping("/users/mypage")
     public ResponseEntity<ApiResult<GetMyPageResponse>> getMyPage(@AuthenticationPrincipal LoginUser loginUser) {
         Long userId = loginUser.getUser().getId();
 
@@ -28,7 +35,7 @@ public class UserController {
         return ResponseEntity.ok(ApiResult.success(response));
     }
 
-    @PatchMapping("/mypage")
+    @PatchMapping("/users/mypage")
     public ResponseEntity<ApiResult<UpdateMyPageResponse>> updateMyPage(
             @AuthenticationPrincipal LoginUser loginUser,
             @RequestBody @Valid UpdateMyPageRequest request) {

--- a/src/main/java/com/my/firstbeat/web/controller/user/dto/request/SignupRequestDto.java
+++ b/src/main/java/com/my/firstbeat/web/controller/user/dto/request/SignupRequestDto.java
@@ -1,0 +1,39 @@
+package com.my.firstbeat.web.controller.user.dto.request;
+
+import com.my.firstbeat.web.controller.user.dto.valid.ValidPassword;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class SignupRequestDto {
+
+    @Email
+    @NotBlank(message = "이메일을 입력하세요")
+    private String email;
+
+    @ValidPassword
+    @NotBlank(message = "비밀번호를 입력하세요")
+    @Pattern(
+            regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,20}$",
+            message = "비밀번호는 영문자와 숫자 조합으로 최소 8글자, 최대 20글자로 입력해주세요."
+    )
+    private String password;
+
+    @NotBlank(message = "이름을 입력해주세요.")
+    @Size(min = 1, message = "이름은 최소 1자 이상 입력해야 합니다.")
+    private String name;
+
+    @Size(min = 3, message = "장르를 반드시 3개 이상 선택해주세요.")
+    private List<String> genreNames;
+}

--- a/src/main/java/com/my/firstbeat/web/controller/user/dto/request/SignupRequestDto.java
+++ b/src/main/java/com/my/firstbeat/web/controller/user/dto/request/SignupRequestDto.java
@@ -1,6 +1,8 @@
 package com.my.firstbeat.web.controller.user.dto.request;
 
 import com.my.firstbeat.web.controller.user.dto.valid.ValidPassword;
+import com.my.firstbeat.web.ex.BusinessException;
+import com.my.firstbeat.web.ex.ErrorCode;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -36,4 +38,13 @@ public class SignupRequestDto {
 
     @Size(min = 3, message = "장르를 반드시 3개 이상 선택해주세요.")
     private List<String> genreNames;
+
+    private List<String> genreIds; // 장르 ID 리스트
+
+    public void validateGenres() {
+        if (genreIds == null || genreIds.size() < 3) {
+            throw new BusinessException(ErrorCode.CHOOSE_AT_LEAST_THREE_GENRE);
+        }
+    }
+
 }

--- a/src/main/java/com/my/firstbeat/web/domain/genre/GenreRepository.java
+++ b/src/main/java/com/my/firstbeat/web/domain/genre/GenreRepository.java
@@ -9,7 +9,12 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.Set;
 import java.util.List;
 
+import java.util.Optional;
+
 public interface GenreRepository extends JpaRepository<Genre, Long> {
+
+    Optional<Genre> findByName(String name);
+
     @Query("SELECT g.id FROM Genre g WHERE g.name IN :names")
     Set<Long> findIdsByNames(@Param("names") Set<String> names);
 

--- a/src/main/java/com/my/firstbeat/web/domain/user/User.java
+++ b/src/main/java/com/my/firstbeat/web/domain/user/User.java
@@ -33,4 +33,11 @@ public class User extends BaseEntity {
         this.role = role;
     }
 
+    public User(String email, String name, String password, Role role) {
+        this.email = email;
+        this.name = name;
+        this.password = password;
+        this.role = role;
+    }
+
 }

--- a/src/main/java/com/my/firstbeat/web/domain/user/UserRepository.java
+++ b/src/main/java/com/my/firstbeat/web/domain/user/UserRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
+    boolean existsByEmail(String email);
+
 }

--- a/src/main/java/com/my/firstbeat/web/domain/userGenre/UserGenre.java
+++ b/src/main/java/com/my/firstbeat/web/domain/userGenre/UserGenre.java
@@ -5,7 +5,6 @@ import com.my.firstbeat.web.domain.genre.Genre;
 import com.my.firstbeat.web.domain.user.User;
 import jakarta.persistence.*;
 import lombok.*;
-import org.yaml.snakeyaml.tokens.ScalarToken;
 
 @Entity
 @Getter

--- a/src/main/java/com/my/firstbeat/web/ex/ErrorCode.java
+++ b/src/main/java/com/my/firstbeat/web/ex/ErrorCode.java
@@ -15,8 +15,11 @@ public enum ErrorCode {
     PLAYLIST_NOT_FOUND("플레이리스트가 존재하지 않습니다.", HttpStatus.NOT_FOUND.value()),
     DUPLICATE_EMAIL("중복된 Email 입니다.", HttpStatus.CONFLICT.value()),
     INVALID_GENRES("유효하지 않은 장르가 포함되어 있습니다.", HttpStatus.BAD_REQUEST.value()),
+    CHOOSE_AT_LEAST_THREE_GENRE("최소 세 가지 이상의 장르를 선택해주세요.", HttpStatus.BAD_REQUEST.value()),
+    CAN_NOT_DELETE_DEFAULT_PLAYLIST("디폴트 플레이리스트는 삭제할 수 없습니다.", HttpStatus.BAD_REQUEST.value()),
     SERVICE_TEMPORARY_UNAVAILABLE("추천 서비스가 일시적으로 혼잡합니다. 잠시 후 다시 시도해주세요", HttpStatus.SERVICE_UNAVAILABLE.value()),
     TRACK_FETCH_ERROR("플레이리스트 내 트랙 목록을 불러오는 중 오류가 발생했습니다", HttpStatus.INTERNAL_SERVER_ERROR.value());
+
 
     private final String message;
     private final int status;

--- a/src/main/java/com/my/firstbeat/web/ex/ErrorCode.java
+++ b/src/main/java/com/my/firstbeat/web/ex/ErrorCode.java
@@ -12,11 +12,10 @@ public enum ErrorCode {
     NO_NEW_RECOMMENDATIONS_AVAILABLE("현재 추천 가능한 새로운 곡이 없습니다. 잠시 후 다시 시도해주세요", HttpStatus.NOT_FOUND.value()),
     DUPLICATE_PLAYLIST_TITLE("이미 존재하는 제목입니다.", HttpStatus.CONFLICT.value()),
     MAX_RECOMMENDATION_ATTEMPTS_EXCEED("일시적으로 추천 서비스를 이용할 수 없습니다. 잠시 후 다시 시도해주세요", HttpStatus.CONFLICT.value()),
-
     PLAYLIST_NOT_FOUND("플레이리스트가 존재하지 않습니다.", HttpStatus.NOT_FOUND.value()),
-
+    DUPLICATE_EMAIL("중복된 Email 입니다.", HttpStatus.CONFLICT.value()),
+    INVALID_GENRES("유효하지 않은 장르가 포함되어 있습니다.", HttpStatus.BAD_REQUEST.value()),
     SERVICE_TEMPORARY_UNAVAILABLE("추천 서비스가 일시적으로 혼잡합니다. 잠시 후 다시 시도해주세요", HttpStatus.SERVICE_UNAVAILABLE.value()),
-
     TRACK_FETCH_ERROR("플레이리스트 내 트랙 목록을 불러오는 중 오류가 발생했습니다", HttpStatus.INTERNAL_SERVER_ERROR.value());
 
     private final String message;

--- a/src/main/java/com/my/firstbeat/web/service/UserService.java
+++ b/src/main/java/com/my/firstbeat/web/service/UserService.java
@@ -1,10 +1,12 @@
 package com.my.firstbeat.web.service;
 
+import com.my.firstbeat.web.controller.user.dto.request.SignupRequestDto;
 import com.my.firstbeat.web.controller.user.dto.request.UpdateMyPageRequest;
 import com.my.firstbeat.web.controller.user.dto.response.GetMyPageResponse;
 import com.my.firstbeat.web.controller.user.dto.response.UpdateMyPageResponse;
 import com.my.firstbeat.web.domain.genre.Genre;
 import com.my.firstbeat.web.domain.genre.GenreRepository;
+import com.my.firstbeat.web.domain.user.Role;
 import com.my.firstbeat.web.domain.user.User;
 import com.my.firstbeat.web.domain.user.UserRepository;
 import com.my.firstbeat.web.domain.userGenre.UserGenre;
@@ -13,10 +15,14 @@ import com.my.firstbeat.web.ex.BusinessException;
 import com.my.firstbeat.web.ex.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -27,8 +33,51 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final UserGenreRepository userGenreRepository;
+    private final PasswordEncoder passwordEncoder;
     private final GenreRepository genreRepository; // GenreRepository 추가
 
+    @Transactional
+    public String signup(SignupRequestDto signupRequestDto) {
+        String name = signupRequestDto.getName();
+        String password = passwordEncoder.encode(signupRequestDto.getPassword());
+        String email = signupRequestDto.getEmail();
+
+        // 이메일 중복 확인
+        Optional<User> checkEmail = userRepository.findByEmail(email);
+        if (checkEmail.isPresent()) {
+            throw new BusinessException(ErrorCode.DUPLICATE_EMAIL);
+        }
+
+        Role role = Role.USER;
+        User user = new User(email, name, password, role);
+
+        // 선택된 장르 이름 가져오기
+        List<String> genreNames = signupRequestDto.getGenreNames();
+
+        // 장르 검증
+        if (genreNames.size() < 3) {
+            throw new BusinessException(ErrorCode.INVALID_GENRES);
+        }
+
+
+        List<Genre> genres = genreNames.stream()
+                .map(n -> genreRepository.findByName(n)
+                        .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_GENRES)))
+                .toList();
+
+
+        // UserGenre 매핑 저장
+        for (Genre genre : genres) {
+            UserGenre userGenre = UserGenre.builder()
+                    .user(user)
+                    .genre(genre)
+                    .build();
+            userGenreRepository.save(userGenre);
+        }
+
+        userRepository.save(user);
+        return "회원가입이 정상적으로 처리되었습니다.";
+    }
 
     public User findByIdOrFail(Long id) {
         return userRepository.findById(id)

--- a/src/main/java/com/my/firstbeat/web/service/UserService.java
+++ b/src/main/java/com/my/firstbeat/web/service/UserService.java
@@ -53,11 +53,6 @@ public class UserService {
         // 선택된 장르 이름 가져오기
         List<String> genreNames = signupRequestDto.getGenreNames();
 
-        // 장르 검증
-        if (genreNames.size() < 3) {
-            throw new BusinessException(ErrorCode.CHOOSE_AT_LEAST_THREE_GENRE);
-        }
-
 
         List<Genre> genres = genreNames.stream()
                 .map(n -> genreRepository.findByName(n)

--- a/src/main/java/com/my/firstbeat/web/service/UserService.java
+++ b/src/main/java/com/my/firstbeat/web/service/UserService.java
@@ -43,8 +43,7 @@ public class UserService {
         String email = signupRequestDto.getEmail();
 
         // 이메일 중복 확인
-        Optional<User> checkEmail = userRepository.findByEmail(email);
-        if (checkEmail.isPresent()) {
+        if (userRepository.existsByEmail(email)) {
             throw new BusinessException(ErrorCode.DUPLICATE_EMAIL);
         }
 
@@ -56,7 +55,7 @@ public class UserService {
 
         // 장르 검증
         if (genreNames.size() < 3) {
-            throw new BusinessException(ErrorCode.INVALID_GENRES);
+            throw new BusinessException(ErrorCode.CHOOSE_AT_LEAST_THREE_GENRE);
         }
 
 

--- a/src/test/java/com/my/firstbeat/web/controller/playlist/PlaylistControllerTest.java
+++ b/src/test/java/com/my/firstbeat/web/controller/playlist/PlaylistControllerTest.java
@@ -3,9 +3,7 @@ package com.my.firstbeat.web.controller.playlist;
 import com.my.firstbeat.web.config.security.loginuser.LoginUser;
 import com.my.firstbeat.web.config.security.loginuser.LoginUserService;
 import com.my.firstbeat.web.controller.playlist.dto.response.TrackListResponse;
-import com.my.firstbeat.web.controller.track.TrackController;
 import com.my.firstbeat.web.domain.track.Track;
-import com.my.firstbeat.web.domain.user.User;
 import com.my.firstbeat.web.dummy.DummyObject;
 import com.my.firstbeat.web.service.PlaylistService;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,16 +15,12 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.http.MediaType;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;

--- a/src/test/java/com/my/firstbeat/web/service/UserServiceRegisterTest.java
+++ b/src/test/java/com/my/firstbeat/web/service/UserServiceRegisterTest.java
@@ -1,0 +1,120 @@
+package com.my.firstbeat.web.service;
+
+import com.my.firstbeat.web.controller.user.dto.request.SignupRequestDto;
+import com.my.firstbeat.web.domain.genre.Genre;
+import com.my.firstbeat.web.domain.genre.GenreRepository;
+import com.my.firstbeat.web.domain.user.User;
+import com.my.firstbeat.web.domain.user.UserRepository;
+import com.my.firstbeat.web.domain.userGenre.UserGenre;
+import com.my.firstbeat.web.domain.userGenre.UserGenreRepository;
+import com.my.firstbeat.web.dummy.DummyObject;
+import com.my.firstbeat.web.ex.BusinessException;
+import com.my.firstbeat.web.ex.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+public class UserServiceRegisterTest extends DummyObject {
+
+    @InjectMocks
+    private UserService userService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserGenreRepository userGenreRepository;
+
+    @Mock
+    private GenreRepository genreRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+    }
+
+    @Test
+    @DisplayName("유저 회원가입 성공 테스트")
+    void testSignup_Success() {
+        // Given
+        SignupRequestDto signupRequestDto = SignupRequestDto.builder()
+                .email("test@example.com")
+                .password("Test1234")
+                .name("Test User")
+                .genreNames(List.of("Rock", "Jazz", "Pop"))
+                .build();
+
+        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.empty());
+        when(passwordEncoder.encode("Test1234")).thenReturn("encodedPassword");
+        when(genreRepository.findByName("Rock")).thenReturn(Optional.of(new Genre(1L, "Rock")));
+        when(genreRepository.findByName("Jazz")).thenReturn(Optional.of(new Genre(2L, "Jazz")));
+        when(genreRepository.findByName("Pop")).thenReturn(Optional.of(new Genre(3L, "Pop")));
+
+        // When
+        String result = userService.signup(signupRequestDto);
+
+        // Then
+        assertThat(result).isEqualTo("회원가입이 정상적으로 처리되었습니다.");
+        verify(userRepository, times(1)).save(any(User.class));
+        verify(userGenreRepository, times(3)).save(any(UserGenre.class));
+    }
+
+    @Test
+    @DisplayName("회원가입시 이메일 중복 테스트")
+    void testSignup_DuplicateEmail() {
+        // Given
+        SignupRequestDto signupRequestDto = SignupRequestDto.builder()
+                .email("test1234@naver.com")
+                .password("Test1234")
+                .name("test name")
+                .genreNames(List.of("Rock", "Jazz", "Pop"))
+                .build();
+
+        when(userRepository.findByEmail("test1234@naver.com")).thenReturn(Optional.of(mockUserWithId(1L)));
+
+        // When & Then
+        BusinessException exception = assertThrows(
+                BusinessException.class,
+                () -> userService.signup(signupRequestDto)
+        );
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.DUPLICATE_EMAIL);
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("장르 유효성 테스트")
+    void testSignup_InvalidGenres() {
+        // Given
+        SignupRequestDto signupRequestDto = SignupRequestDto.builder()
+                .email("test@example.com")
+                .password("Test1234")
+                .name("Test User")
+                .genreNames(List.of("Rock", "Jazz", "Pop"))
+                .build(); // Only one genre
+
+        // When & Then
+        BusinessException exception = assertThrows(
+                BusinessException.class,
+                () -> userService.signup(signupRequestDto)
+        );
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_GENRES);
+        verify(userRepository, never()).save(any(User.class));
+    }
+}

--- a/src/test/java/com/my/firstbeat/web/service/UserServiceRegisterTest.java
+++ b/src/test/java/com/my/firstbeat/web/service/UserServiceRegisterTest.java
@@ -85,7 +85,7 @@ public class UserServiceRegisterTest extends DummyObject {
                 .genreNames(List.of("Rock", "Jazz", "Pop"))
                 .build();
 
-        when(userRepository.findByEmail("test1234@naver.com")).thenReturn(Optional.of(mockUserWithId(1L)));
+        when(userRepository.existsByEmail("test1234@naver.com")).thenReturn(true);
 
         // When & Then
         BusinessException exception = assertThrows(


### PR DESCRIPTION
### 시나리오
- `PETCH` `/api/v1/auth/register`

1. 유저 정보 입력 후 회원가입 요청
2. 입력한 이메일이 이미 존재하는지 확인 -> 중복된다면 오류 반환
3. 입력한 장르가 3개 이상인지 확인 -> 3개 미만이거나 유효하지 않다면 오류 반환

### 단위 테스트 
- UserServiceRegisterTest에서 진행

1. 유저 회원가입 성공 테스트 : 정상 케이스
2. 회원가입 시 이메일 중복 테스트
3. 장르 유효성 테스트