### PR TITLE
플레이리스트 검색 기능 구현

### DIFF
--- a/src/main/java/com/my/firstbeat/web/controller/playlist/PlaylistController.java
+++ b/src/main/java/com/my/firstbeat/web/controller/playlist/PlaylistController.java
@@ -81,8 +81,9 @@ public class PlaylistController {
     @GetMapping
     public ApiResult<PlaylistsData> getPlaylists(
             @RequestParam(defaultValue = "") String query,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size) {
+            @RequestParam(value = "page", defaultValue = "0", required = false) @PositiveOrZero int page,
+            @RequestParam(value = "size", defaultValue = "10", required = false) @Range(min = 1, max = 100, message = "페이지 크기는 1에서 100 사이여야 합니다") int size
+    ) {
 
         Page<Playlist> playlistPage = playlistService.searchPlaylists(query, page, size);
 

--- a/src/main/java/com/my/firstbeat/web/controller/playlist/PlaylistController.java
+++ b/src/main/java/com/my/firstbeat/web/controller/playlist/PlaylistController.java
@@ -2,6 +2,7 @@ package com.my.firstbeat.web.controller.playlist;
 
 import com.my.firstbeat.web.config.security.loginuser.LoginUser;
 import com.my.firstbeat.web.controller.playlist.dto.request.PlaylistCreateRequest;
+import com.my.firstbeat.web.controller.playlist.dto.response.*;
 import com.my.firstbeat.web.controller.playlist.dto.response.PlaylistCreateResponse;
 import com.my.firstbeat.web.controller.playlist.dto.response.TrackListResponse;
 import com.my.firstbeat.web.controller.playlist.dto.response.PlaylistRetrieveResponse;
@@ -20,7 +21,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/v1/playlist")
@@ -72,4 +78,30 @@ public class PlaylistController {
 		return ResponseEntity.ok(ApiResult.success(playlistService.getTrackList(playlistId, page, size)));
 	}
 
+    @GetMapping
+    public ApiResult<PlaylistsData> getPlaylists(
+            @RequestParam(defaultValue = "") String query,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+
+        Page<Playlist> playlistPage = playlistService.searchPlaylists(query, page, size);
+
+        List<PlaylistSearchResponse> playlists = playlistPage.stream()
+                .map(playlist -> new PlaylistSearchResponse(
+                        playlist.getId(),
+                        playlist.getTitle(),
+                        playlist.getDescription(),
+                        playlist.getUser().getName()
+                ))
+                .collect(Collectors.toList());
+
+        PaginationInfo pagination = new PaginationInfo(
+                playlistPage.getNumber() + 1,
+                playlistPage.getSize(),
+                playlistPage.getTotalPages(),
+                (int) playlistPage.getTotalElements()
+        );
+
+        return ApiResult.success(new PlaylistsData(playlists, pagination));
+    }
 }

--- a/src/main/java/com/my/firstbeat/web/controller/playlist/dto/response/PaginationInfo.java
+++ b/src/main/java/com/my/firstbeat/web/controller/playlist/dto/response/PaginationInfo.java
@@ -2,7 +2,6 @@ package com.my.firstbeat.web.controller.playlist.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor

--- a/src/main/java/com/my/firstbeat/web/controller/playlist/dto/response/PaginationInfo.java
+++ b/src/main/java/com/my/firstbeat/web/controller/playlist/dto/response/PaginationInfo.java
@@ -1,0 +1,14 @@
+package com.my.firstbeat.web.controller.playlist.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+public class PaginationInfo {
+    private int page;
+    private int limit;
+    private int totalPages;
+    private int totalItems;
+}

--- a/src/main/java/com/my/firstbeat/web/controller/playlist/dto/response/PlaylistSearchResponse.java
+++ b/src/main/java/com/my/firstbeat/web/controller/playlist/dto/response/PlaylistSearchResponse.java
@@ -1,0 +1,13 @@
+package com.my.firstbeat.web.controller.playlist.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PlaylistSearchResponse {
+    private Long playlistId;
+    private String name;
+    private String description;
+    private String createdBy;
+}

--- a/src/main/java/com/my/firstbeat/web/controller/playlist/dto/response/PlaylistsData.java
+++ b/src/main/java/com/my/firstbeat/web/controller/playlist/dto/response/PlaylistsData.java
@@ -1,0 +1,15 @@
+package com.my.firstbeat.web.controller.playlist.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class PlaylistsData {
+
+    private final List<PlaylistSearchResponse> playlists;
+    private final PaginationInfo pagination;
+
+}

--- a/src/main/java/com/my/firstbeat/web/domain/playlist/PlaylistRepository.java
+++ b/src/main/java/com/my/firstbeat/web/domain/playlist/PlaylistRepository.java
@@ -3,14 +3,13 @@ package com.my.firstbeat.web.domain.playlist;
 
 import com.my.firstbeat.web.domain.track.Track;
 import com.my.firstbeat.web.domain.user.User;
-import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import java.util.List;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PlaylistRepository extends JpaRepository<Playlist, Long> {
@@ -26,7 +25,6 @@ public interface PlaylistRepository extends JpaRepository<Playlist, Long> {
 
 	//특정 사용자의 디폴트 플레이리스트 조회
 	Optional<Playlist> findByUserIdAndIsDefault(Long userId, boolean isDefault);
-
 
     Page<Playlist> findByUserId(Long userId, Pageable pageable);
 

--- a/src/main/java/com/my/firstbeat/web/domain/playlist/PlaylistRepository.java
+++ b/src/main/java/com/my/firstbeat/web/domain/playlist/PlaylistRepository.java
@@ -17,7 +17,6 @@ public interface PlaylistRepository extends JpaRepository<Playlist, Long> {
 
     boolean existsByUserAndTitle(User user, String title);
 
-
     @Query("select t from Playlist p " +
             "join PlaylistTrack pt on pt.playlist = p " +
             "join Track t on pt.track = t " +
@@ -31,4 +30,5 @@ public interface PlaylistRepository extends JpaRepository<Playlist, Long> {
 
     Page<Playlist> findByUserId(Long userId, Pageable pageable);
 
+    Page<Playlist> findByTitleContaining(String query, Pageable pageable);
 }

--- a/src/main/java/com/my/firstbeat/web/service/PlaylistService.java
+++ b/src/main/java/com/my/firstbeat/web/service/PlaylistService.java
@@ -121,5 +121,10 @@ public class PlaylistService {
         newDefaultPlaylist.updateDefault(true);
         playlistRepository.save(newDefaultPlaylist);
     }
+
+    public Page<Playlist> searchPlaylists(String query, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        return playlistRepository.findByTitleContaining(query, pageable);
+    }
 }
 

--- a/src/main/java/com/my/firstbeat/web/service/UserService.java
+++ b/src/main/java/com/my/firstbeat/web/service/UserService.java
@@ -96,7 +96,6 @@ public class UserService {
             Set<Long> genreIdsToAdd = genreRepository.findIdsByNames(genresToAdd);
             List<Genre> genresToAddList = genreRepository.findAllById(genreIdsToAdd);
             for (Genre genre : genresToAddList) {
-                log.info("genres: " + genre.getName());
                 UserGenre userGenre = UserGenre.builder()
                         .user(user)
                         .genre(genre)

--- a/src/test/java/com/my/firstbeat/web/service/PlaylistSearchV1Test.java
+++ b/src/test/java/com/my/firstbeat/web/service/PlaylistSearchV1Test.java
@@ -1,0 +1,55 @@
+package com.my.firstbeat.web.service;
+
+import com.my.firstbeat.web.domain.playlist.Playlist;
+import com.my.firstbeat.web.domain.playlist.PlaylistRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+class PlaylistSearchV1Test {
+
+    @InjectMocks
+    private PlaylistService playlistService;
+
+    @Mock
+    private PlaylistRepository playlistRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("플레이리스트 검색 테스트")
+    void searchPlaylists_Success() {
+        // Given
+        String query = "Top Hits";
+        int page = 0;
+        int size = 10;
+        PageRequest pageRequest = PageRequest.of(page, size);
+
+        Playlist playlist1 = new Playlist("Top Hits", "Weekly Top Hits", null);
+        Playlist playlist2 = new Playlist("Top Pop", "Top Pop Hits", null);
+
+        Page<Playlist> playlistsPage = new PageImpl<>(List.of(playlist1, playlist2), pageRequest, 2);
+        when(playlistRepository.findByTitleContaining(query, pageRequest)).thenReturn(playlistsPage);
+
+        // When
+        Page<Playlist> result = playlistService.searchPlaylists(query, page, size);
+
+        // Then
+        assertEquals(2, result.getTotalElements());
+        assertEquals("Top Hits", result.getContent().get(0).getTitle());
+    }
+}


### PR DESCRIPTION
### 시나리오
- `GET` `/api/v1/playlists`

1. 검색어를 통해 플레이리스트 검색
2. 제목에 검색어가 포함되어있는 플레이리스트 반환

### 단위 테스트 
- PlaylistSearchV1Test에서 진행

1. 플레이리스트 반환 : 정상 케이스