### PR TITLE
플레이리스트 검색 구현 및 인기 검색어 캐시 구현(인메모리 캐시를 곁들인..)

### DIFF
--- a/src/main/java/com/my/firstbeat/web/config/cache/CacheConfig.java
+++ b/src/main/java/com/my/firstbeat/web/config/cache/CacheConfig.java
@@ -7,12 +7,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.util.Queue;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.ReentrantLock;
 
 @Configuration
 @EnableCaching
@@ -31,4 +31,8 @@ public class CacheConfig {
                 .build();
     }
 
+    @Bean
+    public CacheManager inMemoryCacheManager() {
+        return new ConcurrentMapCacheManager("popularSearches");
+    }
 }

--- a/src/main/java/com/my/firstbeat/web/controller/playlist/PlaylistController.java
+++ b/src/main/java/com/my/firstbeat/web/controller/playlist/PlaylistController.java
@@ -6,6 +6,7 @@ import com.my.firstbeat.web.controller.playlist.dto.response.*;
 import com.my.firstbeat.web.controller.playlist.dto.response.PlaylistCreateResponse;
 import com.my.firstbeat.web.controller.playlist.dto.response.TrackListResponse;
 import com.my.firstbeat.web.controller.playlist.dto.response.PlaylistRetrieveResponse;
+import com.my.firstbeat.web.controller.playlist.dto.response.*;
 import com.my.firstbeat.web.domain.playlist.Playlist;
 import com.my.firstbeat.web.service.PlaylistService;
 import com.my.firstbeat.web.util.api.ApiResult;
@@ -24,6 +25,9 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 import java.util.List;
 import java.util.stream.Collectors;

--- a/src/main/java/com/my/firstbeat/web/controller/playlist/PlaylistController.java
+++ b/src/main/java/com/my/firstbeat/web/controller/playlist/PlaylistController.java
@@ -73,7 +73,7 @@ public class PlaylistController {
     }
 
     @GetMapping("/v1/playlist")
-    public ApiResult<PlaylistsData> getPlaylists(
+    public ResponseEntity<ApiResult<PlaylistsData>> getPlaylists(
             @RequestParam(defaultValue = "") String query,
             @RequestParam(value = "page", defaultValue = "0", required = false) @PositiveOrZero int page,
             @RequestParam(value = "size", defaultValue = "10", required = false) @Range(min = 1, max = 100, message = "페이지 크기는 1에서 100 사이여야 합니다") int size
@@ -97,6 +97,6 @@ public class PlaylistController {
                 (int) playlistPage.getTotalElements()
         );
 
-        return ApiResult.success(new PlaylistsData(playlists, pagination));
+        return ResponseEntity.ok(ApiResult.success(new PlaylistsData(playlists, pagination)));
     }
 }

--- a/src/main/java/com/my/firstbeat/web/controller/playlist/PlaylistController.java
+++ b/src/main/java/com/my/firstbeat/web/controller/playlist/PlaylistController.java
@@ -3,10 +3,6 @@ package com.my.firstbeat.web.controller.playlist;
 import com.my.firstbeat.web.config.security.loginuser.LoginUser;
 import com.my.firstbeat.web.controller.playlist.dto.request.PlaylistCreateRequest;
 import com.my.firstbeat.web.controller.playlist.dto.response.*;
-import com.my.firstbeat.web.controller.playlist.dto.response.PlaylistCreateResponse;
-import com.my.firstbeat.web.controller.playlist.dto.response.TrackListResponse;
-import com.my.firstbeat.web.controller.playlist.dto.response.PlaylistRetrieveResponse;
-import com.my.firstbeat.web.controller.playlist.dto.response.*;
 import com.my.firstbeat.web.domain.playlist.Playlist;
 import com.my.firstbeat.web.service.PlaylistService;
 import com.my.firstbeat.web.util.api.ApiResult;
@@ -14,20 +10,14 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.PositiveOrZero;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.validator.constraints.Range;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -41,7 +31,7 @@ public class PlaylistController {
     private final PlaylistService playlistService;
 
     // 플레이리스트 생성
-    @PostMapping
+    @PostMapping("/v1/playlist")
     public ResponseEntity<ApiResult<PlaylistCreateResponse>> createPlaylist(
             @AuthenticationPrincipal LoginUser loginUser,
             @Valid @RequestBody PlaylistCreateRequest request) {
@@ -49,7 +39,7 @@ public class PlaylistController {
     }
 
     // 내가 만든 플레이리스트 조회: 최신순 정렬, 페이징
-    @GetMapping("/me")
+    @GetMapping("/v1/playlist/me")
     public ResponseEntity<ApiResult<Page<PlaylistRetrieveResponse>>> getMyPlaylists(
             @AuthenticationPrincipal LoginUser loginUser,
             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
@@ -57,7 +47,7 @@ public class PlaylistController {
     }
 
     // 디폴트 플레이리스트 가져오기 또는 생성
-    @GetMapping("/default")
+    @GetMapping("/v1/playlist/default")
     public ResponseEntity<ApiResult<Playlist>> getDefaultPlaylist(
             @AuthenticationPrincipal LoginUser user) {
         // 현재 로그인한 사용자의 디폴트 플레이리스트 가져오기 또는 생성
@@ -65,24 +55,24 @@ public class PlaylistController {
         return ResponseEntity.ok(ApiResult.success(defaultPlaylist));
     }
 
-	// 디폴트 플레이리스트 변경
-	@PutMapping("/{playlistId}/default/")
-	public ResponseEntity<ApiResult<String>> changeDefaultPlaylist(
-		@PathVariable(value = "playlistId") Long playlistId,
-		@AuthenticationPrincipal LoginUser user) {
-		playlistService.changeDefaultPlaylist(user.getUser().getId(), playlistId);
-		return ResponseEntity.ok(ApiResult.success("디폴트 플레이리스트가 변경되었습니다."));
-	}
+    // 디폴트 플레이리스트 변경
+    @PutMapping("/v1/playlist/{playlistId}/default/")
+    public ResponseEntity<ApiResult<String>> changeDefaultPlaylist(
+            @PathVariable(value = "playlistId") Long playlistId,
+            @AuthenticationPrincipal LoginUser user) {
+        playlistService.changeDefaultPlaylist(user.getUser().getId(), playlistId);
+        return ResponseEntity.ok(ApiResult.success("디폴트 플레이리스트가 변경되었습니다."));
+    }
 
-	@GetMapping("/{playlistId}")
-	public ResponseEntity<ApiResult<TrackListResponse>> getTrackList(
-			@PathVariable(value = "playlistId") Long playlistId,
-		    @RequestParam(value = "page", defaultValue = "0", required = false) @PositiveOrZero int page,
-		    @RequestParam(value = "size", defaultValue = "10", required = false) @Range(min = 1, max = 100, message = "페이지 크기는 1에서 100 사이여야 합니다") int size) {
-		return ResponseEntity.ok(ApiResult.success(playlistService.getTrackList(playlistId, page, size)));
-	}
+    @GetMapping("/{playlistId}")
+    public ResponseEntity<ApiResult<TrackListResponse>> getTrackList(
+            @PathVariable(value = "playlistId") Long playlistId,
+            @RequestParam(value = "page", defaultValue = "0", required = false) @PositiveOrZero int page,
+            @RequestParam(value = "size", defaultValue = "10", required = false) @Range(min = 1, max = 100, message = "페이지 크기는 1에서 100 사이여야 합니다") int size) {
+        return ResponseEntity.ok(ApiResult.success(playlistService.getTrackList(playlistId, page, size)));
+    }
 
-    @GetMapping
+    @GetMapping("/v1/playlist")
     public ApiResult<PlaylistsData> getPlaylists(
             @RequestParam(defaultValue = "") String query,
             @RequestParam(value = "page", defaultValue = "0", required = false) @PositiveOrZero int page,

--- a/src/main/java/com/my/firstbeat/web/controller/playlist/SearchController.java
+++ b/src/main/java/com/my/firstbeat/web/controller/playlist/SearchController.java
@@ -1,0 +1,27 @@
+package com.my.firstbeat.web.controller.playlist;
+
+import com.my.firstbeat.web.service.SearchService;
+import com.my.firstbeat.web.util.api.ApiResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class SearchController {
+
+    private final SearchService searchService;
+
+    @GetMapping("/v2/searches/trending-searches")
+    public ResponseEntity<ApiResult<List<String>>> getPopularSearches(
+            @RequestParam(defaultValue = "5") int topN) {
+        List<String> popularSearches = searchService.getTopSearches(topN);
+        return ResponseEntity.ok(ApiResult.success(popularSearches));
+    }
+}

--- a/src/main/java/com/my/firstbeat/web/domain/playlist/PopularSearchCache.java
+++ b/src/main/java/com/my/firstbeat/web/domain/playlist/PopularSearchCache.java
@@ -1,0 +1,25 @@
+package com.my.firstbeat.web.domain.playlist;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+public class PopularSearchCache {
+
+    private final Map<String, Integer> searchCounts = new ConcurrentHashMap<>();
+
+    // 검색어 추가 및 횟수 증가
+    public void addSearch(String keyword) {
+        searchCounts.merge(keyword, 1, Integer::sum);
+    }
+
+    // 상위 n개의 인기 검색어 조회
+    public List<String> getTopSearches(int n) {
+        return searchCounts.entrySet().stream()
+                .sorted((a, b) -> b.getValue().compareTo(a.getValue())) // 검색 횟수 기준으로 내림차순 정렬
+                .limit(n)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/my/firstbeat/web/service/SearchService.java
+++ b/src/main/java/com/my/firstbeat/web/service/SearchService.java
@@ -1,0 +1,25 @@
+package com.my.firstbeat.web.service;
+
+import com.my.firstbeat.web.domain.playlist.PopularSearchCache;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+
+@Service
+public class SearchService {
+
+    private final PopularSearchCache popularSearchCache = new PopularSearchCache();
+
+    public void recordSearch(String keyword) {
+        popularSearchCache.addSearch(keyword);
+    }
+
+    public List<String> getTopSearches(int limit) {
+        return popularSearchCache.getTopSearches(limit);
+    }
+}

--- a/src/main/java/com/my/firstbeat/web/service/recommemdation/RecommendationServiceWithRedis.java
+++ b/src/main/java/com/my/firstbeat/web/service/recommemdation/RecommendationServiceWithRedis.java
@@ -31,7 +31,6 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)

--- a/src/test/java/com/my/firstbeat/web/service/PlaylistServiceTest.java
+++ b/src/test/java/com/my/firstbeat/web/service/PlaylistServiceTest.java
@@ -43,19 +43,20 @@ class PlaylistServiceTest extends DummyObject {
 
     @InjectMocks
     private PlaylistService playlistService;
-  
+
   	@Mock
 	private UserRepository userRepository;
 
     @Mock
     private TrackRepository trackRepository;
-  
+
+    @Mock
+    private SearchService searchService;
+
   	@BeforeEach
 	void setUp() {
 		MockitoAnnotations.openMocks(this); // Mock 객체 초기화
 	}
-
-
 
     @Test
     @DisplayName("플레이리스트 생성: 정상")
@@ -245,7 +246,7 @@ class PlaylistServiceTest extends DummyObject {
 			  pageable,
 			  2
 	  );
-		PlaylistService realService = new PlaylistService(playlistRepository, userRepository, trackRepository);
+		PlaylistService realService = new PlaylistService(playlistRepository, userRepository, trackRepository, searchService);
 		PlaylistService spyService = spy(realService);
 
 		doReturn(playlist).when(spyService).findByIdOrFail(playlistId);
@@ -266,7 +267,7 @@ class PlaylistServiceTest extends DummyObject {
 	@DisplayName("플레이리스트 내 추천 트랙 반환: 존재하지 않는 플레이리스트 조회 시 예외 발생")
 	void getTrackList_PlaylistNotFound() {
 		Long playlistId = 999L;
-		PlaylistService realService = new PlaylistService(playlistRepository, userRepository, trackRepository);
+		PlaylistService realService = new PlaylistService(playlistRepository, userRepository, trackRepository, searchService);
 		PlaylistService spyService = spy(realService);
 		doThrow(new BusinessException(ErrorCode.PLAYLIST_NOT_FOUND))
 				.when(spyService).findByIdOrFail(playlistId);
@@ -288,7 +289,7 @@ class PlaylistServiceTest extends DummyObject {
 				.description("내꺼")
 				.build();
 
-		PlaylistService realService = new PlaylistService(playlistRepository, userRepository, trackRepository);
+		PlaylistService realService = new PlaylistService(playlistRepository, userRepository, trackRepository, searchService);
 		PlaylistService spyService = spy(realService);
 
 		doReturn(playlist).when(spyService).findByIdOrFail(playlistId);
@@ -302,9 +303,5 @@ class PlaylistServiceTest extends DummyObject {
 		assertEquals(ErrorCode.TRACK_FETCH_ERROR, exception.getErrorCode());
 		verify(trackRepository).findAllByPlaylist(any(), any());
 	}
-
-
-
-
 }
 

--- a/src/test/java/com/my/firstbeat/web/service/SearchServiceTest.java
+++ b/src/test/java/com/my/firstbeat/web/service/SearchServiceTest.java
@@ -1,0 +1,40 @@
+package com.my.firstbeat.web.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SearchServiceTest {
+
+    private SearchService searchService;
+
+    @BeforeEach
+    void setUp() {
+        searchService = new SearchService();
+    }
+
+    @Test
+    @DisplayName("검색어 기록 및 인기 검색어 조회 테스트")
+    void testRecordSearchAndGetTopSearches() {
+        // Given
+        searchService.recordSearch("Spring Boot");
+        searchService.recordSearch("Spring Boot");
+        searchService.recordSearch("Microservices");
+        searchService.recordSearch("Microservices");
+        searchService.recordSearch("Microservices");
+        searchService.recordSearch("Docker");
+
+        // When
+        List<String> topSearches = searchService.getTopSearches(3);
+
+        // Then
+        assertEquals(3, topSearches.size());
+        assertEquals("Microservices", topSearches.get(0));
+        assertEquals("Spring Boot", topSearches.get(1));
+        assertEquals("Docker", topSearches.get(2));
+    }
+}


### PR DESCRIPTION
### 시나리오
- `GET` `/api/v2/playlists`

1. 검색어를 통해 플레이리스트 검색
2. 제목에 검색어가 포함되어있는 플레이리스트 반환
3. 인기 검색어를 캐싱 및 조회 api를 호출 시 반환

### 테스트 
- SearchServiceTest에서 진행

1. 플레이리스트 반환 : 정상 케이스